### PR TITLE
Regen Sim on Load to populate paths

### DIFF
--- a/ui/views/Load.tsx
+++ b/ui/views/Load.tsx
@@ -3,6 +3,7 @@ import { Sim } from "@core/sim";
 import type { Save } from "@core/db";
 import { createBaseConfig } from "@core/sim/baseConfig";
 import LZString from "lz-string";
+import { regen } from "@core/systems/pathPlanning";
 import { useLocation } from "../context/Location";
 import { Saves } from "../components/Saves";
 import { View } from "../components/View";
@@ -29,6 +30,7 @@ export const LoadGame: React.FC = () => {
                 LZString.decompress(saves.find((s) => s.id === id)!.data)
               );
               setSim(sim);
+              regen(sim);
               navigate("game");
             }}
             onDelete={async (id) => {


### PR DESCRIPTION
I don't know if this bug was introduced with compressing saves but when loading a save, populating the ships fails due to an error related to sim.paths not being populated.

To reproduce, simply save and load the game.

This one-liner fixes the issue by regenerating the path calculations upon load.