### PR TITLE
Add selected unit panel

### DIFF
--- a/core/systems/rendering/rendering.ts
+++ b/core/systems/rendering/rendering.ts
@@ -76,6 +76,7 @@ export class RenderingSystem extends SystemWithHooks<"graphics"> {
   displayRange: boolean;
   scale: number;
   contextMenuApi: ContextMenuApi;
+  lastClicked: number;
 
   constructor(contextMenuApi: ContextMenuApi) {
     super();
@@ -363,6 +364,12 @@ export class RenderingSystem extends SystemWithHooks<"graphics"> {
           sprite.addEventListener("pointerdown", (event) => {
             if (event.button === 0) {
               this.settingsManager.cp.selectionManager.id = entity.id;
+
+              if (Date.now() - this.lastClicked < 200) {
+                this.settingsManager.cp.selectionManager.focused = true;
+              }
+
+              this.lastClicked = Date.now();
             }
           });
           sprite.addEventListener("rightdown", () => {

--- a/ui/components/Crew/Crew.stories.tsx
+++ b/ui/components/Crew/Crew.stories.tsx
@@ -21,7 +21,6 @@ const Template: StoryFn<typeof Crew> = (args) => (
       <PanelComponent
         isCollapsed={false}
         onCollapseToggle={action("onCollapseToggle")}
-        onFocus={action("onFocus")}
         onPlayerAssets={action("onPlayerAssets")}
       >
         <Crew {...args} />

--- a/ui/components/Offers/Offers.stories.tsx
+++ b/ui/components/Offers/Offers.stories.tsx
@@ -23,7 +23,6 @@ const Template: StoryFn<typeof Offers> = (args) => (
       <PanelComponent
         isCollapsed={false}
         onCollapseToggle={action("onCollapseToggle")}
-        onFocus={action("onFocus")}
         onPlayerAssets={action("onPlayerAssets")}
       >
         <Offers {...args} />

--- a/ui/components/Panel/Panel.tsx
+++ b/ui/components/Panel/Panel.tsx
@@ -119,15 +119,6 @@ export const Panel: React.FC<PanelProps> = ({ entity, expanded }) => {
       <PanelComponent
         isCollapsed={isCollapsed}
         onCollapseToggle={toggleCollapse}
-        onFocus={
-          entity
-            ? () => {
-                sim.find((e) =>
-                  e.hasComponents(["selectionManager"])
-                )!.cp.selectionManager!.focused = true;
-              }
-            : undefined
-        }
         onPlayerAssets={() => {
           sim.queries.settings.get()[0].cp.selectionManager.id = null;
         }}

--- a/ui/components/Panel/PanelComponent.tsx
+++ b/ui/components/Panel/PanelComponent.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import clsx from "clsx";
 import { IconButton } from "@kit/IconButton";
 import { AnimatedBackdrop } from "@kit/AnimatedBackdrop";
-import { ArrowLeftIcon, JournalIcon, LocationIcon } from "@assets/ui/icons";
+import { ArrowLeftIcon, JournalIcon } from "@assets/ui/icons";
 import styles from "./Panel.scss";
 
 export interface PanelComponentProps {
@@ -10,14 +10,12 @@ export interface PanelComponentProps {
   isCollapsed: boolean;
   onCollapseToggle: () => void;
   onPlayerAssets: () => void;
-  onFocus: (() => void) | undefined;
 }
 
 export const PanelComponent: React.FC<PanelComponentProps> = ({
   isCollapsed,
   onCollapseToggle,
   onPlayerAssets,
-  onFocus,
   children,
 }) => (
   <AnimatedBackdrop
@@ -39,11 +37,6 @@ export const PanelComponent: React.FC<PanelComponentProps> = ({
       <IconButton onClick={onPlayerAssets}>
         <JournalIcon />
       </IconButton>
-      {!!onFocus && (
-        <IconButton onClick={onFocus}>
-          <LocationIcon />
-        </IconButton>
-      )}
       {!isCollapsed && (
         <>
           <div className={styles.spacer} />

--- a/ui/components/SelectedUnit/SelectedUnit.tsx
+++ b/ui/components/SelectedUnit/SelectedUnit.tsx
@@ -23,7 +23,10 @@ export const SelectedUnit: React.FC = () => {
           sim.queries.settings.get()[0].cp.selectionManager.focused = true;
         }}
       >
-        <Text variant="caption">{selectedUnit.cp.name!.value}</Text>
+        <Text variant="caption">
+          {selectedUnit.cp.name?.value ??
+            (selectedUnit.hasTags(["collectible"]) ? "Collectible" : "Unknown")}
+        </Text>
       </div>
     </div>
   );

--- a/ui/components/SelectedUnit/SelectedUnit.tsx
+++ b/ui/components/SelectedUnit/SelectedUnit.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { getSelected } from "@core/components/selection";
+import Text from "@kit/Text";
+import { useSim } from "../../atoms";
+import styles from "./styles.scss";
+
+export const SelectedUnit: React.FC = () => {
+  const [sim] = useSim();
+  const selectedUnit = React.useMemo(
+    () => getSelected(sim),
+    [sim.queries.settings.get()[0].cp.selectionManager.id]
+  );
+
+  if (!selectedUnit) {
+    return null;
+  }
+
+  return (
+    <div className={styles.root}>
+      <div
+        className={styles.panel}
+        onDoubleClick={() => {
+          sim.queries.settings.get()[0].cp.selectionManager.focused = true;
+        }}
+      >
+        <Text variant="caption">{selectedUnit.cp.name!.value}</Text>
+      </div>
+    </div>
+  );
+};
+
+SelectedUnit.displayName = "SelectedUnit";

--- a/ui/components/SelectedUnit/index.ts
+++ b/ui/components/SelectedUnit/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectedUnit";

--- a/ui/components/SelectedUnit/styles.scss
+++ b/ui/components/SelectedUnit/styles.scss
@@ -1,0 +1,20 @@
+.root {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.panel {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border: 1px solid var(--palette-border);
+  border-bottom: none;
+  background-color: var(--palette-background-active);
+  cursor: pointer;
+  text-align: center;
+  width: 250px;
+  padding: var(--spacing-1) var(--spacing-2);
+  line-height: 1;
+}

--- a/ui/components/SelectedUnit/styles.scss.d.ts
+++ b/ui/components/SelectedUnit/styles.scss.d.ts
@@ -1,0 +1,5 @@
+/* @generated */
+/* prettier-ignore */
+/* eslint-disable */
+export const root: string;
+export const panel: string;

--- a/ui/components/Storage/Storage.stories.tsx
+++ b/ui/components/Storage/Storage.stories.tsx
@@ -22,7 +22,6 @@ const Template: StoryFn<typeof Storage> = (args) => (
       <PanelComponent
         isCollapsed={false}
         onCollapseToggle={action("onCollapseToggle")}
-        onFocus={action("onFocus")}
         onPlayerAssets={action("onPlayerAssets")}
       >
         <Storage {...args} />

--- a/ui/views/Game.tsx
+++ b/ui/views/Game.tsx
@@ -19,6 +19,7 @@ import { Notifications } from "@ui/components/Notifications";
 import { SimControl } from "@ui/components/SimControl/SimControl";
 import DevOverlay from "@ui/components/DevOverlay/DevOverlay";
 import { useGameSettings } from "@ui/hooks/useGameSettings";
+import { SelectedUnit } from "@ui/components/SelectedUnit";
 import styles from "./Game.scss";
 
 import { Panel } from "../components/Panel";
@@ -147,6 +148,7 @@ const Game: React.FC = () => {
       <div className={styles.canvasRoot} ref={canvasRoot} id="canvasRoot">
         <PlayerMoney />
         <SimControl />
+        <SelectedUnit />
         <MapPanel
           tabs={
             <>


### PR DESCRIPTION
Added new panel indicating which unit is currently selected by player. Hint: double-click to focus view on this unit.

<img width="394" alt="Screenshot 2024-03-27 at 01 22 00" src="https://github.com/sectoralphagame/sector-alpha/assets/6833443/f3adc578-b5a4-4418-b628-b069e664261d">
