### PR TITLE
Fix Tau incursions

### DIFF
--- a/core/components/orders.ts
+++ b/core/components/orders.ts
@@ -66,7 +66,7 @@ export type Action =
   | BuilderDeployAction
   | CollectAction;
 export interface BaseOrder {
-  origin: "auto" | "manual";
+  origin: string;
   actions: Action[];
   interrupt?: boolean;
 }

--- a/core/systems/ai/orderPlanning.ts
+++ b/core/systems/ai/orderPlanning.ts
@@ -55,7 +55,7 @@ function idleMovement(entity: RequireComponent<"position" | "orders">) {
     entity.sim.getOrThrow<Waypoint>(entity.cp.commander.id);
 
   entity.cp.orders.value.push({
-    origin: "auto",
+    origin: "OrderPlanningSystem:auto",
     actions: moveToActions(
       entity,
       createWaypoint(
@@ -115,7 +115,7 @@ function autoTrade(entity: Trading, sectorDistance: number) {
 
       if (actions) {
         entity.cp.orders.value.push({
-          origin: "auto",
+          origin: "OrderPlanningSystem:auto",
           type: "trade",
           actions,
         });
@@ -249,7 +249,7 @@ function autoMine(
     }
 
     entity.cp.orders.value.push({
-      origin: "auto",
+      origin: "OrderPlanningSystem:auto",
       type: "mine",
       actions: [
         ...moveToActions(entity, field),
@@ -336,7 +336,7 @@ function autoMineForCommander(
       }
 
       entity.cp.orders.value.push({
-        origin: "auto",
+        origin: "OrderPlanningSystem:auto",
         type: "mine",
         actions: [
           ...moveToActions(entity, field),
@@ -365,7 +365,7 @@ function escortCommander(
         actions: [],
         type: "escort",
         ordersForSector: 0,
-        origin: "auto",
+        origin: "OrderPlanningSystem:auto",
         targetId: commander.id,
       },
     ];
@@ -391,7 +391,7 @@ function autoOrder(entity: RequireComponent<"autoOrder" | "orders">) {
           {
             ...entity.cp.autoOrder.default,
             actions: [],
-            origin: "auto",
+            origin: "OrderPlanningSystem:auto",
             clockwise: Math.random() > 0.5,
           },
         ];

--- a/core/systems/ai/tauHarassing.ts
+++ b/core/systems/ai/tauHarassing.ts
@@ -92,7 +92,7 @@ export class TauHarassingSystem extends System<"exec"> {
           ship.cp.dockable?.size === "small" &&
           ship.tags.has("role:military") &&
           !ship.tags.has("ai:attack-force") &&
-          ship.cp.orders.value.length === 0
+          (ship.cp.orders.value.length === 0 || ship.tags.has("ai:spare"))
       );
 
     const fightersInShipyards = fullQueue.filter(
@@ -184,7 +184,7 @@ export class TauHarassingSystem extends System<"exec"> {
     commander.cp.orders.value.push({
       type: "pillage",
       actions: [],
-      origin: "auto",
+      origin: this.constructor.name,
       sectorId: invadedSector.id,
       clockwise: Math.random() > 0.5,
     });

--- a/core/systems/orderExecuting/orderExecuting.ts
+++ b/core/systems/orderExecuting/orderExecuting.ts
@@ -160,11 +160,13 @@ function cleanupDocks(entity: Entity): void {
 
   if (entity.cp.dockable?.dockedIn) {
     const dockedIn = entity.sim
-      .getOrThrow(entity.cp.dockable?.dockedIn)
-      .requireComponents(["docks"]);
-    dockedIn.cp.docks.docked = dockedIn.cp.docks.docked.filter(
-      (id) => id !== entity.id
-    );
+      .get(entity.cp.dockable?.dockedIn)
+      ?.requireComponents(["docks"]);
+    if (dockedIn) {
+      dockedIn.cp.docks.docked = dockedIn.cp.docks.docked.filter(
+        (id) => id !== entity.id
+      );
+    }
   }
 }
 

--- a/core/tags.ts
+++ b/core/tags.ts
@@ -14,6 +14,7 @@ const tags = [
   "virtual",
   "collectible",
   "ai:attack-force",
+  "ai:spare",
   ...shipRoles.map<`role:${ShipRole}`>((role) => `role:${role}`),
   ...modules.map<`facilityModuleType:${FacilityModuleType}`>(
     ({ type: facilityModuleType }) =>


### PR DESCRIPTION
After some time The Hive turned into a real hive, because of accumulation of patrolling ships which should instead be used to pillage nearby sector. This PR fixes it.

![image](https://github.com/sectoralphagame/sector-alpha/assets/6833443/c4c8de78-507d-4fb1-a8c8-a46e362cf0ce)
