### PR TITLE
Rename Query to Index

### DIFF
--- a/core/sim/Sim.ts
+++ b/core/sim/Sim.ts
@@ -17,8 +17,8 @@ import { Observable } from "@core/utils/observer";
 import { Entity, EntityComponents } from "../entity";
 import { BaseSim } from "./BaseSim";
 import type { System } from "../systems/system";
-import type { Queries } from "../systems/utils/query";
-import { Query, createQueries } from "../systems/utils/query";
+import type { Queries } from "../systems/utils/entityIndex";
+import { Index, createQueries } from "../systems/utils/entityIndex";
 import { MissingEntityError } from "../errors";
 import { openDb } from "../db";
 
@@ -219,11 +219,11 @@ export class Sim extends BaseSim {
     );
     const sim = plainToInstance(Sim, save);
     config.systems.forEach((system) => system.apply(sim));
-    Object.values(sim.queries).forEach((queryOrNested) => {
-      if (queryOrNested instanceof Query) {
-        queryOrNested.reset();
+    Object.values(sim.queries).forEach((indexOrNested) => {
+      if (indexOrNested instanceof Index) {
+        indexOrNested.reset();
       } else {
-        Object.values(queryOrNested).forEach((query) => query.reset());
+        Object.values(indexOrNested).forEach((index) => index.reset());
       }
     });
     const entityMap = new Map();

--- a/core/systems/ai/militaryModuleSpotting.ts
+++ b/core/systems/ai/militaryModuleSpotting.ts
@@ -4,23 +4,23 @@ import { facilityComponents } from "@core/archetypes/facility";
 import { pickRandom } from "@core/utils/generators";
 import { System } from "../system";
 import type { Sim } from "../../sim";
-import { Query } from "../utils/query";
+import { Index } from "../utils/entityIndex";
 import { SpottingSystem } from "./spotting";
-import { SectorQuery } from "../utils/sectorQuery";
+import { SectorIndex } from "../utils/sectorIndex";
 import { isInDistance } from "../attacking";
 
 export class MilitaryModuleSpottingSystem extends System<"exec"> {
-  queries: {
-    enemies: SectorQuery<"hitpoints" | "owner" | "position">;
-    modules: Query<"parent" | "damage">;
+  indexes: {
+    enemies: SectorIndex<"hitpoints" | "owner" | "position">;
+    modules: Index<"parent" | "damage">;
   };
 
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.queries = {
-      enemies: new SectorQuery(sim, ["hitpoints", "owner", "position"]),
-      modules: new Query(sim, ["parent", "damage"], ["facilityModule"]),
+    this.indexes = {
+      enemies: new SectorIndex(sim, ["hitpoints", "owner", "position"]),
+      modules: new Index(sim, ["parent", "damage"], ["facilityModule"]),
     };
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
@@ -34,7 +34,7 @@ export class MilitaryModuleSpottingSystem extends System<"exec"> {
       Array<RequireComponent<"hitpoints" | "owner" | "position">>
     > = {};
 
-    this.queries.modules.get().forEach((entity) => {
+    this.indexes.modules.get().forEach((entity) => {
       const facility = this.sim.getOrThrow<Facility>(entity.cp.parent.id);
       if (
         !facility.cp.owner ||
@@ -46,7 +46,7 @@ export class MilitaryModuleSpottingSystem extends System<"exec"> {
 
       const enemy = pickRandom(
         SpottingSystem.getEnemies(
-          this.queries.enemies.get(facility.cp.position.sector),
+          this.indexes.enemies.get(facility.cp.position.sector),
           cache,
           facility.requireComponents([...facilityComponents, "owner"])
         ).slice(0, 3)

--- a/core/systems/ai/spotting.ts
+++ b/core/systems/ai/spotting.ts
@@ -6,7 +6,7 @@ import type { RequireComponent } from "@core/tsHelpers";
 import { pickRandom } from "@core/utils/generators";
 import { System } from "../system";
 import type { Sim } from "../../sim";
-import { SectorQuery } from "../utils/sectorQuery";
+import { SectorIndex } from "../utils/sectorIndex";
 
 export const spottingRadius = 6;
 
@@ -16,12 +16,12 @@ export type EnemyArrayCache = Record<
 >;
 
 export class SpottingSystem extends System<"exec"> {
-  query: SectorQuery<"hitpoints" | "owner" | "position">;
+  index: SectorIndex<"hitpoints" | "owner" | "position">;
 
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.query = new SectorQuery(sim, ["hitpoints", "owner", "position"]);
+    this.index = new SectorIndex(sim, ["hitpoints", "owner", "position"]);
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
@@ -103,7 +103,7 @@ export class SpottingSystem extends System<"exec"> {
 
       const enemy = pickRandom(
         SpottingSystem.getEnemies(
-          this.query.get(entity.cp.position.sector),
+          this.index.get(entity.cp.position.sector),
           cache,
           entity
         ).slice(0, 3)

--- a/core/systems/attacking.ts
+++ b/core/systems/attacking.ts
@@ -8,7 +8,7 @@ import { distance } from "mathjs";
 import type { DockSize } from "@core/components/dockable";
 import type { Entity } from "@core/entity";
 import { regenCooldown } from "./hitpointsRegenerating";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 const sizeMultipliers: Record<DockSize, [number, number, number]> = {
@@ -69,12 +69,12 @@ function attack(attacker: RequireComponent<"orders">, target: Entity) {
 const cdKey = "attack";
 
 export class AttackingSystem extends System {
-  query: Query<"damage">;
+  index: Index<"damage">;
 
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["damage"]);
+    this.index = new Index(sim, ["damage"]);
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
@@ -82,7 +82,7 @@ export class AttackingSystem extends System {
   exec = (): void => {
     if (this.sim.getTime() < settings.bootTime) return;
 
-    for (const entity of this.query.getIt()) {
+    for (const entity of this.index.getIt()) {
       if (entity.cp.damage.targetId && entity.cooldowns.canUse(cdKey)) {
         if (!this.sim.entities.has(entity.cp.damage.targetId)) {
           entity.cp.damage.targetId = null;

--- a/core/systems/budgetPlanning.ts
+++ b/core/systems/budgetPlanning.ts
@@ -4,7 +4,7 @@ import type { WithTrade } from "../economy/utils";
 import { getPlannedBudget } from "../economy/utils";
 import type { Sim } from "../sim";
 import { limitMax } from "../utils/limit";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 function settleBudget(entity: WithTrade) {
@@ -28,19 +28,19 @@ function settleBudget(entity: WithTrade) {
 }
 
 export class BudgetPlanningSystem extends System<"exec"> {
-  query: Query<"budget" | "owner" | "trade">;
+  index: Index<"budget" | "owner" | "trade">;
 
   apply = (sim: Sim): void => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["budget", "owner", "trade"]);
+    this.index = new Index(sim, ["budget", "owner", "trade"]);
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
 
   exec = (): void => {
     if (this.cooldowns.canUse("exec")) {
       this.cooldowns.use("exec", 5 * 60);
-      this.query
+      this.index
         .get()
         .filter((entity) => entity.sim.getOrThrow(entity.cp.owner.id).cp.ai)
         .forEach(settleBudget);

--- a/core/systems/deadUnregistering.ts
+++ b/core/systems/deadUnregistering.ts
@@ -1,22 +1,22 @@
 import type { Sim } from "@core/sim";
 import { dumpCargo } from "@core/components/storage";
 import type { Faction } from "@core/archetypes/faction";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 export class DeadUnregisteringSystem extends System {
-  query: Query<"hitpoints">;
+  index: Index<"hitpoints">;
 
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["hitpoints"]);
+    this.index = new Index(sim, ["hitpoints"]);
 
     sim.hooks.phase.cleanup.subscribe(this.constructor.name, this.exec);
   };
 
   exec = (): void => {
-    for (const entity of this.query.getIt()) {
+    for (const entity of this.index.getIt()) {
       if (entity.cp.hitpoints.hp.value <= 0) {
         if (entity.cp.storage) {
           dumpCargo(entity.requireComponents(["storage"]));

--- a/core/systems/hitpointsRegenerating.ts
+++ b/core/systems/hitpointsRegenerating.ts
@@ -1,16 +1,16 @@
 import type { Sim } from "@core/sim";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 export const regenCooldown = "regen";
 
 export class HitpointsRegeneratingSystem extends System<"exec"> {
-  query: Query<"hitpoints">;
+  index: Index<"hitpoints">;
 
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["hitpoints"]);
+    this.index = new Index(sim, ["hitpoints"]);
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
@@ -19,7 +19,7 @@ export class HitpointsRegeneratingSystem extends System<"exec"> {
     if (!this.cooldowns.canUse("exec")) return;
 
     this.cooldowns.use("exec", 1);
-    for (const entity of this.query.getIt()) {
+    for (const entity of this.index.getIt()) {
       if (!entity.cooldowns.canUse(regenCooldown)) continue;
       entity.cp.hitpoints.hp.value = Math.min(
         entity.cp.hitpoints.hp.value +

--- a/core/systems/moving.ts
+++ b/core/systems/moving.ts
@@ -1,7 +1,7 @@
 import { normalizeAngle } from "@core/utils/misc";
 import type { Sim } from "../sim";
 import type { RequireComponent } from "../tsHelpers";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 type Driveable = RequireComponent<"drive" | "position">;
@@ -40,19 +40,19 @@ function move(entity: Driveable, delta: number) {
 
 export class MovingSystem extends System {
   entities: Driveable[];
-  query: Query<"drive" | "position">;
+  index: Index<"drive" | "position">;
 
   apply = (sim: Sim): void => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["drive", "position"]);
+    this.index = new Index(sim, ["drive", "position"]);
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
 
   exec = (delta: number): void => {
     if (delta > 0) {
-      for (const entity of this.query.getIt()) {
+      for (const entity of this.index.getIt()) {
         move(entity, delta);
       }
     }

--- a/core/systems/navigating.ts
+++ b/core/systems/navigating.ts
@@ -9,7 +9,7 @@ import {
 } from "../components/drive";
 import type { Sim } from "../sim";
 import type { RequireComponent } from "../tsHelpers";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 type Driveable = RequireComponent<"drive" | "position">;
@@ -259,18 +259,18 @@ function setDrive(entity: Driveable, delta: number) {
 
 export class NavigatingSystem extends System {
   entities: Driveable[];
-  query: Query<"drive" | "position">;
+  index: Index<"drive" | "position">;
 
   apply = (sim: Sim): void => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["drive", "position"]);
+    this.index = new Index(sim, ["drive", "position"]);
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
 
   exec = (delta: number): void => {
-    for (const entity of this.query.getIt()) {
+    for (const entity of this.index.getIt()) {
       setDrive(entity, delta);
     }
   };

--- a/core/systems/orderExecuting/misc.ts
+++ b/core/systems/orderExecuting/misc.ts
@@ -7,7 +7,7 @@ import {
 } from "../../components/drive";
 import type { MoveAction, TeleportAction } from "../../components/orders";
 import type { RequireComponent } from "../../tsHelpers";
-import { SectorQuery } from "../utils/sectorQuery";
+import { SectorIndex } from "../utils/sectorIndex";
 import { undockShip } from "./dock";
 
 export function moveActionCleanup(
@@ -75,10 +75,10 @@ export function teleportAction(
       sector: destination.cp.position.sector,
       moved: true,
     };
-    SectorQuery.notify(prevSector, destination.cp.position.sector, docked);
+    SectorIndex.notify(prevSector, destination.cp.position.sector, docked);
   });
 
-  SectorQuery.notify(prevSector, destination.cp.position.sector, entity);
+  SectorIndex.notify(prevSector, destination.cp.position.sector, entity);
 
   return true;
 }

--- a/core/systems/pirateSpawning.ts
+++ b/core/systems/pirateSpawning.ts
@@ -15,7 +15,7 @@ import { shipClasses } from "@core/world/ships";
 import { filter, find, map, pipe, toArray } from "@fxts/core";
 import { add, distance, random, randomInt } from "mathjs";
 import { System } from "./system";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 
 const flagshipDistanceFromSectorCenter =
   ((1 + Math.random() / 5) * sectorSize) / 15;
@@ -157,7 +157,7 @@ export class PirateSpawningSystem extends System<
   "return" | "spawnFlagship" | "spawnSquad"
 > {
   faction: Faction;
-  query: Query<ShipComponent>;
+  index: Index<ShipComponent>;
 
   moveFlagship = (flagships: Ship[]) => {
     const shipToMove = pickRandom(
@@ -196,7 +196,7 @@ export class PirateSpawningSystem extends System<
   };
 
   exec = (): void => {
-    const ships = this.query.get();
+    const ships = this.index.get();
 
     const squads = pipe(
       ships,
@@ -257,7 +257,7 @@ export class PirateSpawningSystem extends System<
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.query = new Query<ShipComponent>(sim, shipComponents, [
+    this.index = new Index<ShipComponent>(sim, shipComponents, [
       "role:military",
     ]);
 

--- a/core/systems/rendering/rendering.ts
+++ b/core/systems/rendering/rendering.ts
@@ -19,7 +19,7 @@ import type { Cooldowns } from "../../utils/cooldowns";
 import { SystemWithHooks } from "../utils/hooks";
 import { clearFocus } from "../../components/selection";
 import type { Layer, Textures } from "../../components/render";
-import { SectorQuery } from "../utils/sectorQuery";
+import { SectorIndex } from "../utils/sectorIndex";
 import { drawHpBars } from "./hpBars";
 
 const minScale = 0.08;
@@ -70,7 +70,7 @@ export class RenderingSystem extends SystemWithHooks<"graphics"> {
   overlay: HTMLDivElement;
   grid: RequireComponent<"renderGraphics"> | null = null;
   layers: Record<Layer, PIXI.Container>;
-  sectorQuery: SectorQuery<"render">;
+  sectorIndex: SectorIndex<"render">;
   sprites: Map<Entity, PIXI.Sprite> = new Map();
   graphics: Map<Entity, PIXI.Graphics> = new Map();
   displayRange: boolean;
@@ -89,7 +89,7 @@ export class RenderingSystem extends SystemWithHooks<"graphics"> {
       (window as any).rendering = this;
     }
 
-    this.sectorQuery = new SectorQuery(sim, ["render"]);
+    this.sectorIndex = new SectorIndex(sim, ["render"]);
     sim.hooks.phase.render.subscribe("RenderingSystem", this.exec);
   };
 

--- a/core/systems/undeploying.ts
+++ b/core/systems/undeploying.ts
@@ -3,7 +3,7 @@ import type { DeployableType } from "@core/components/deployable";
 import type { Sim } from "@core/sim";
 import type { RequireComponent } from "@core/tsHelpers";
 import { removeSubordinate } from "@core/components/subordinates";
-import { Query } from "./utils/query";
+import { Index } from "./utils/entityIndex";
 import { System } from "./system";
 
 const handlers: Partial<
@@ -47,12 +47,12 @@ const handlers: Partial<
 };
 
 export class UndeployingSystem extends System<"exec"> {
-  query: Query<"deployable">;
+  index: Index<"deployable">;
 
   apply = (sim: Sim) => {
     super.apply(sim);
 
-    this.query = new Query(sim, ["deployable"]);
+    this.index = new Index(sim, ["deployable"]);
 
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
@@ -60,7 +60,7 @@ export class UndeployingSystem extends System<"exec"> {
   exec = (): void => {
     if (this.cooldowns.canUse("exec")) {
       this.cooldowns.use("exec", 1);
-      this.query.get().forEach((entity) => {
+      this.index.get().forEach((entity) => {
         if (entity.cp.deployable.cancel) {
           handlers[entity.cp.deployable.type]?.(entity);
         }


### PR DESCRIPTION
It makes more sense to call it `Index` as there is no querying happening here.