### PR TITLE
Add fog of war

### DIFF
--- a/core/sim/Sim.ts
+++ b/core/sim/Sim.ts
@@ -218,14 +218,6 @@ export class Sim extends BaseSim {
         : v
     );
     const sim = plainToInstance(Sim, save);
-    config.systems.forEach((system) => system.apply(sim));
-    Object.values(sim.queries).forEach((indexOrNested) => {
-      if (indexOrNested instanceof Index) {
-        indexOrNested.reset();
-      } else {
-        Object.values(indexOrNested).forEach((index) => index.reset());
-      }
-    });
     const entityMap = new Map();
 
     sim.entities.forEach((entity) => {
@@ -244,6 +236,15 @@ export class Sim extends BaseSim {
     });
 
     sim.entities = entityMap;
+
+    config.systems.forEach((system) => system.apply(sim));
+    Object.values(sim.queries).forEach((indexOrNested) => {
+      if (indexOrNested instanceof Index) {
+        indexOrNested.reset();
+      } else {
+        Object.values(indexOrNested).forEach((index) => index.reset());
+      }
+    });
 
     return sim;
   }

--- a/core/sim/baseConfig.ts
+++ b/core/sim/baseConfig.ts
@@ -38,6 +38,7 @@ import { ShipBuildingSystem } from "@core/systems/shipBuilding";
 import { StorageQuotaPlanningSystem } from "@core/systems/storageQuotaPlanning";
 import { TradingSystem } from "@core/systems/trading";
 import { UndeployingSystem } from "@core/systems/undeploying";
+import { FogOfWarUpdatingSystem } from "@core/systems/fogOfWarUpdating";
 import type { SimConfig } from "./Sim";
 
 export const bootstrapSystems = [
@@ -88,6 +89,7 @@ export const createBaseConfig = (): SimConfig => {
         }
       ),
       new PirateSpawningSystem(),
+      new FogOfWarUpdatingSystem(),
     ],
   };
 

--- a/core/systems/ai/facilityPlanning.ts
+++ b/core/systems/ai/facilityPlanning.ts
@@ -11,7 +11,6 @@ import { facilityModules } from "../../archetypes/facilityModule";
 import type { Faction } from "../../archetypes/faction";
 import type { Sector } from "../../archetypes/sector";
 import { sectorSize } from "../../archetypes/sector";
-import { hecsToCartesian } from "../../components/hecsPosition";
 import type { PAC } from "../../components/production";
 import { addStorage } from "../../components/storage";
 import type { Commodity } from "../../economy/commodity";
@@ -65,16 +64,12 @@ function getSectorPosition(
   radius?: number,
   point?: Position2D
 ): Position2D {
-  const sectorPosition = hecsToCartesian(
-    sector.cp.hecsPosition.value,
-    sectorSize / 10
-  );
   let position: Position2D;
   let isNearAnyFacility: boolean;
   const r = radius ?? -sectorSize / 20;
 
   do {
-    position = add(point ?? sectorPosition, [
+    position = add(point ?? [0, 0], [
       random(-r, r),
       random(-r, r),
     ]) as Position2D;
@@ -104,16 +99,12 @@ export class FacilityPlanningSystem extends System<"plan"> {
         .get()
         .filter((s) => s.cp.owner?.id === faction.id)
     );
-    const sectorPosition = hecsToCartesian(
-      sector.cp.hecsPosition.value,
-      sectorSize / 10
-    );
     const facility = createFacility(this.sim, {
       owner: faction,
-      position: add(sectorPosition, [
+      position: [
         random(-sectorSize / 20, sectorSize / 20),
         random(-sectorSize / 20, sectorSize / 20),
-      ]) as Position2D,
+      ],
       sector,
     });
     facility.cp.name.value = createFacilityName(facility, "Factory");
@@ -212,12 +203,10 @@ export class FacilityPlanningSystem extends System<"plan"> {
     for (const sector of this.sim.queries.sectors.getIt()) {
       if (sector.cp.owner?.id !== faction.id) continue;
 
-      const position = hecsToCartesian(
-        sector.cp.hecsPosition.value,
-        sectorSize / 10
-      );
-      position[0] += random(-sectorSize / 50, sectorSize / 50);
-      position[1] += random(-sectorSize / 50, sectorSize / 50);
+      const position: Position2D = [
+        random(-sectorSize / 50, sectorSize / 50),
+        random(-sectorSize / 50, sectorSize / 50),
+      ];
 
       const facility = createFacility(this.sim, {
         owner: faction,

--- a/core/systems/ai/orderPlanning.ts
+++ b/core/systems/ai/orderPlanning.ts
@@ -130,9 +130,12 @@ function autoTrade(entity: Trading, sectorDistance: number) {
         (entity.cp.autoOrder.default as TradeOrder).sectorId!
       ),
       sectorDistance,
-      Object.entries(owner.cp.relations.values)
-        .filter(([, value]) => value < relationThresholds.trade)
-        .map(([id]) => Number(id))
+      (f) =>
+        !Object.entries(owner.cp.relations.values)
+          .filter(([, value]) => value < relationThresholds.trade)
+          .map(([id]) => Number(id))
+          .includes(f.cp.owner.id) &&
+        (owner.tags.has("player") ? f.tags.has("discovered") : true)
     );
     if (trade) {
       makingTrade = resellCommodity(

--- a/core/systems/ai/shipReturning.ts
+++ b/core/systems/ai/shipReturning.ts
@@ -1,12 +1,9 @@
 import type { Faction } from "@core/archetypes/faction";
 import { createWaypoint } from "@core/archetypes/waypoint";
-import { sectorSize } from "@core/archetypes/sector";
-import { hecsToCartesian } from "@core/components/hecsPosition";
 import type { Sim } from "@core/sim";
 import { moveToActions } from "@core/utils/moving";
 import { each, filter, first, map, pipe, sortBy } from "@fxts/core";
-import { add, random } from "mathjs";
-import type { Position2D } from "@core/components/position";
+import { random } from "mathjs";
 import { System } from "../system";
 
 /**
@@ -62,13 +59,7 @@ export class ShipReturningSystem extends System<"exec"> {
               createWaypoint(this.sim, {
                 sector: closestSector.id,
                 owner: ship.id,
-                value: add(
-                  hecsToCartesian(
-                    closestSector.cp.hecsPosition!.value,
-                    sectorSize / 10
-                  ),
-                  [random(-5, 5), random(-5, 5)]
-                ) as Position2D,
+                value: [random(-5, 5), random(-5, 5)],
               })
             ),
             origin: "auto",

--- a/core/systems/ai/spotting.ts
+++ b/core/systems/ai/spotting.ts
@@ -8,7 +8,7 @@ import { System } from "../system";
 import type { Sim } from "../../sim";
 import { SectorIndex } from "../utils/sectorIndex";
 
-export const spottingRadius = 6;
+export const spottingRadius = 5;
 
 export type EnemyArrayCache = Record<
   string,

--- a/core/systems/fogOfWarUpdating.ts
+++ b/core/systems/fogOfWarUpdating.ts
@@ -1,0 +1,140 @@
+import type { Sim } from "@core/sim";
+import { Entity } from "@core/entity";
+import { createRenderGraphics } from "@core/components/renderGraphics";
+import type { RequireComponent } from "@core/tsHelpers";
+import { sectorSize } from "@core/archetypes/sector";
+import type { Position2D } from "@core/components/position";
+import { System } from "./system";
+import { Index } from "./utils/entityIndex";
+
+let sectorMaps: Record<number, Uint8Array> = {};
+const divisions = 2 ** 6;
+
+export class FogOfWarUpdatingSystem extends System<"exec"> {
+  grid: RequireComponent<"renderGraphics"> | null = null;
+  index: Index<"position" | "owner">;
+  enabled = true;
+
+  apply = (sim: Sim): void => {
+    super.apply(sim);
+
+    this.grid =
+      sim
+        .find(
+          (e) =>
+            e.tags.has("virtual") &&
+            e.cp.renderGraphics?.draw === "fogOfWarGrid"
+        )
+        ?.requireComponents(["renderGraphics"]) ?? null;
+
+    if (!this.grid) {
+      this.initGrid();
+    }
+
+    sim.actions.register(
+      {
+        category: "drawing",
+        type: "basic",
+        description: "Show fog of war grid",
+        name: "Fog of war grid",
+        slug: "fogOfWarGrid",
+        // eslint-disable-next-line no-shadow
+        fn: (sim) => {
+          if (this.grid) {
+            sim.unregisterEntity(this.grid);
+            this.grid = null;
+          } else {
+            this.initGrid();
+          }
+        },
+      },
+      this.constructor.name
+    );
+
+    sim.actions.register(
+      {
+        category: "core",
+        type: "basic",
+        description: "Toggle fog of war",
+        name: "Fog of war",
+        fn: () => {
+          this.enabled = !this.enabled;
+        },
+        slug: "fogOfWar",
+      },
+      this.constructor.name
+    );
+
+    this.index = new Index(sim, ["position", "owner"]);
+    sim.hooks.phase.init.subscribe(this.constructor.name, this.updateFog);
+  };
+
+  initGrid = () => {
+    const grid = new Entity(this.sim);
+
+    this.grid = grid
+      .addTag("virtual")
+      .addComponent(createRenderGraphics("fogOfWarGrid"))
+      .requireComponents(["renderGraphics"]);
+  };
+
+  updateFog = () => {
+    this.cooldowns.doEvery("exec", 0.3, () => {
+      sectorMaps = {};
+
+      const player = this.sim.queries.player.get()[0];
+
+      for (const entity of this.index.getIt()) {
+        const position = entity.cp.position;
+        const owner = entity.cp.owner;
+        if (owner.id !== player.id) continue;
+
+        const sectorId = position.sector;
+        if (!sectorMaps[sectorId]) {
+          sectorMaps[sectorId] = new Uint8Array(divisions ** 2);
+        }
+
+        const [x, y] = FogOfWarUpdatingSystem.getBox(position.coord);
+
+        const r = entity.tags.has("facility") ? 7 : 4;
+
+        for (let i = -r; i <= r; i++) {
+          for (let j = -r; j <= r; j++) {
+            if (i ** 2 + j ** 2 > r ** 2) continue;
+            sectorMaps[sectorId][(y + i) * divisions + x + j] = 1;
+          }
+        }
+      }
+
+      for (const entity of this.sim.queries.orderable.getIt()) {
+        if (entity.cp.dockable?.dockedIn) continue;
+
+        if (!this.enabled) {
+          entity.cp.render!.visible = true;
+        } else {
+          const [x, y] = FogOfWarUpdatingSystem.getBox(
+            entity.cp.position.coord
+          );
+
+          if (entity.cp.owner.id !== player.id) {
+            entity.cp.render!.visible =
+              !!sectorMaps[entity.cp.position.sector]?.[y * divisions + x];
+          }
+        }
+      }
+
+      if (this.grid) {
+        this.grid.cp.renderGraphics.redraw = true;
+      }
+    });
+  };
+
+  static getBox = (pos: Position2D): [number, number] => [
+    Math.floor((pos[0] * divisions) / 2 / (sectorSize / 10) + divisions / 2),
+    Math.floor((pos[1] * divisions) / 2 / (sectorSize / 10) + divisions / 2),
+  ];
+
+  static getMaps = () => sectorMaps;
+
+  static getDivisions = () => divisions;
+}

--- a/core/systems/mission/destroy.ts
+++ b/core/systems/mission/destroy.ts
@@ -2,13 +2,11 @@ import Mustache from "mustache";
 import type { Mission, MissionCommon } from "@core/components/missions";
 import { relationThresholds } from "@core/components/relations";
 import { pickRandom } from "@core/utils/generators";
-import { add, random, randomInt } from "mathjs";
+import { random, randomInt } from "mathjs";
 import { first, map, pipe, repeat, toArray } from "@fxts/core";
 import { createShip } from "@core/archetypes/ship";
 import { shipClasses } from "@core/world/ships";
-import { hecsToCartesian } from "@core/components/hecsPosition";
 import { addSubordinate } from "@core/components/subordinates";
-import { sectorSize } from "@core/archetypes/sector";
 import type { Position2D } from "@core/components/position";
 import type { Sim } from "@core/sim";
 import missions from "../../world/data/missions.json";
@@ -68,19 +66,13 @@ export const destroyMissionHandler: MissionHandler = {
       .get()
       .find((f) => f.cp.name.slug === "PIR")!;
     const shipClass = shipClasses.find((s) => s.slug === "roach")!;
-    const spawnPoint = hecsToCartesian(
-      sector.cp.hecsPosition.value,
-      sectorSize / 10
-    );
+    const spawnPoint: Position2D = [randomInt(-0.3, 0.3), randomInt(-0.3, 0.3)];
     const entities = pipe(
       repeat(randomInt(2, 4), () =>
         createShip(sim, {
           ...shipClass,
           owner: pirateFaction,
-          position: add(spawnPoint, [
-            randomInt(-0.3, 0.3),
-            randomInt(-0.3, 0.3),
-          ]) as Position2D,
+          position: spawnPoint,
           sector,
         })
       ),

--- a/core/systems/orderExecuting/patrol.ts
+++ b/core/systems/orderExecuting/patrol.ts
@@ -1,9 +1,8 @@
 import { createWaypoint } from "@core/archetypes/waypoint";
 import { sectorSize } from "@core/archetypes/sector";
 import type { Sector } from "@core/archetypes/sector";
-import { hecsToCartesian } from "@core/components/hecsPosition";
 import { random } from "lodash";
-import { add, multiply, randomInt, subtract } from "mathjs";
+import { multiply, randomInt } from "mathjs";
 import type { Position2D } from "@core/components/position";
 import type { PatrolOrder } from "../../components/orders";
 import type { RequireComponent } from "../../tsHelpers";
@@ -16,31 +15,23 @@ export function patrolOrder(
   const targetSector = entity.sim.getOrThrow<Sector>(order.sectorId);
 
   if (order.actions.length === 0) {
-    const sectorPosition = hecsToCartesian(
-      targetSector.cp.hecsPosition.value,
-      sectorSize / 10
-    );
-
     let waypointPosition: Position2D;
 
     if (entity.cp.position.sector === targetSector.id) {
-      const pos = subtract(entity.cp.position.coord, sectorPosition);
+      const pos = entity.cp.position.coord;
       const angle = Math.atan2(pos[1], pos[0]);
       const angleOffset =
         (Math.PI / randomInt(4, 8)) * (order.clockwise ? 1 : -1);
 
-      waypointPosition = add(
-        sectorPosition,
-        multiply(
-          [Math.cos(angle + angleOffset), Math.sin(angle + angleOffset)],
-          random(sectorSize / 30, sectorSize / 15)
-        )
+      waypointPosition = multiply(
+        [Math.cos(angle + angleOffset), Math.sin(angle + angleOffset)],
+        random(sectorSize / 30, sectorSize / 15)
       ) as Position2D;
     } else {
-      waypointPosition = add(sectorPosition, [
+      waypointPosition = [
         random(-sectorSize / 20, sectorSize / 20),
         random(-sectorSize / 20, sectorSize / 20),
-      ]) as Position2D;
+      ];
     }
 
     entity.cp.orders.value[0].actions = moveToActions(

--- a/core/systems/pirateSpawning.ts
+++ b/core/systems/pirateSpawning.ts
@@ -4,8 +4,6 @@ import { sectorSize } from "@core/archetypes/sector";
 import type { Ship, ShipComponent } from "@core/archetypes/ship";
 import { createShip, shipComponents } from "@core/archetypes/ship";
 import { createWaypoint } from "@core/archetypes/waypoint";
-import { hecsToCartesian } from "@core/components/hecsPosition";
-import type { Position2D } from "@core/components/position";
 import { addSubordinate } from "@core/components/subordinates";
 import { isDev } from "@core/settings";
 import type { Sim } from "@core/sim";
@@ -13,7 +11,7 @@ import { pickRandom } from "@core/utils/generators";
 import { moveToActions } from "@core/utils/moving";
 import { shipClasses } from "@core/world/ships";
 import { filter, find, map, pipe, toArray } from "@fxts/core";
-import { add, distance, random, randomInt } from "mathjs";
+import { distance, random, randomInt } from "mathjs";
 import { System } from "./system";
 import { Index } from "./utils/entityIndex";
 
@@ -77,13 +75,10 @@ function spawnFlagship(sim: Sim, faction: Faction, flagships: Ship[]) {
     owner: faction,
     sector,
     angle: Math.random() * 2 * Math.PI,
-    position: add(
-      hecsToCartesian(sector.cp.hecsPosition.value, sectorSize / 10),
-      [
-        Math.cos(angle) * flagshipDistanceFromSectorCenter,
-        Math.sin(angle) * flagshipDistanceFromSectorCenter,
-      ]
-    ) as Position2D,
+    position: [
+      Math.cos(angle) * flagshipDistanceFromSectorCenter,
+      Math.sin(angle) * flagshipDistanceFromSectorCenter,
+    ],
   });
 }
 
@@ -166,14 +161,9 @@ export class PirateSpawningSystem extends System<
 
     if (!shipToMove) return;
 
-    const sectorPosition = hecsToCartesian(
-      this.sim.getOrThrow<Sector>(shipToMove.cp.position.sector).cp.hecsPosition
-        .value,
-      sectorSize / 10
-    );
     const angle = Math.atan2(
-      shipToMove.cp.position.coord[1] - sectorPosition[1],
-      shipToMove.cp.position.coord[0] - sectorPosition[0]
+      shipToMove.cp.position.coord[1],
+      shipToMove.cp.position.coord[0]
     );
     const dAngle =
       (random(8, 20) * (Math.random() > 0.5 ? 1 : -1) * 2 * Math.PI) / 360;
@@ -184,10 +174,10 @@ export class PirateSpawningSystem extends System<
         shipToMove,
         createWaypoint(this.sim, {
           sector: shipToMove.cp.position.sector,
-          value: add(sectorPosition, [
+          value: [
             flagshipDistanceFromSectorCenter * Math.cos(angle + dAngle),
             flagshipDistanceFromSectorCenter * Math.sin(angle + dAngle),
-          ]) as Position2D,
+          ],
           owner: shipToMove.id,
         })
       ),

--- a/core/systems/rendering/rendering.ts
+++ b/core/systems/rendering/rendering.ts
@@ -8,8 +8,9 @@ import { isHeadless } from "@core/settings";
 import { first } from "@fxts/core";
 import { storageHook } from "@core/hooks";
 import type { ContextMenuApi } from "@ui/atoms";
-import { worldToHecs } from "@core/components/hecsPosition";
+import { hecsToCartesian, worldToHecs } from "@core/components/hecsPosition";
 import { deepEqual } from "mathjs";
+import { sectorSize, type Sector } from "@core/archetypes/sector";
 import {
   createRenderGraphics,
   graphics,
@@ -348,7 +349,11 @@ export class RenderingSystem extends SystemWithHooks<"graphics"> {
 
   updateRenderables = () => {
     for (const sectorId of this.sectorIndex.sectors.keys()) {
-      // const sector = this.sim.getOrThrow<Sector>(sectorId)
+      const sector = this.sim.getOrThrow<Sector>(sectorId);
+      const sectorPos = hecsToCartesian(
+        sector.cp.hecsPosition.value,
+        sectorSize / 10
+      );
 
       for (const entity of this.sectorIndex.sectors.get(sectorId)!) {
         const entityRender = entity.cp.render;
@@ -390,8 +395,8 @@ export class RenderingSystem extends SystemWithHooks<"graphics"> {
           entity.cp.position.moved = false;
 
           sprite!.position.set(
-            entity.cp.position.coord[0] * 10,
-            entity.cp.position.coord[1] * 10
+            (sectorPos[0] + entity.cp.position.coord[0]) * 10,
+            (sectorPos[1] + entity.cp.position.coord[1]) * 10
           );
           sprite!.rotation = entity.cp.position.angle;
         }

--- a/core/systems/reporting/outOfBoundsChecking.ts
+++ b/core/systems/reporting/outOfBoundsChecking.ts
@@ -4,28 +4,30 @@ import type { Sim } from "@core/sim";
 import type { RequireComponent } from "@core/tsHelpers";
 import { deepEqual } from "mathjs";
 import { System } from "../system";
+import { Index } from "../utils/entityIndex";
 
 export class OutOfBoundsCheckingSystem extends System<"exec"> {
+  index: Index<"position">;
+
   apply = (sim: Sim) => {
     super.apply(sim);
+    this.index = new Index(this.sim, ["position"]);
 
     sim.hooks.phase.start.subscribe(this.constructor.name, this.exec);
   };
   exec = (): void => {
     if (this.cooldowns.canUse("exec")) {
       this.cooldowns.use("exec", this.sim.speed);
-      const outOfBoundsEntities = this.sim.queries.renderable
-        .get()
-        .reduce((acc, entity) => {
-          const sector = this.sim.getOrThrow<Sector>(entity.cp.position.sector);
-          const hecsCoors = worldToHecs(entity.cp.position.coord);
+      const outOfBoundsEntities = this.index.get().reduce((acc, entity) => {
+        const sector = this.sim.getOrThrow<Sector>(entity.cp.position.sector);
+        const hecsCoors = worldToHecs(entity.cp.position.coord);
 
-          if (!deepEqual(hecsCoors, sector.cp.hecsPosition.value)) {
-            acc.push(entity);
-          }
+        if (!deepEqual(hecsCoors, sector.cp.hecsPosition.value)) {
+          acc.push(entity);
+        }
 
-          return acc;
-        }, [] as RequireComponent<"position">[]);
+        return acc;
+      }, [] as RequireComponent<"position">[]);
 
       if (outOfBoundsEntities.length > 0) {
         // eslint-disable-next-line no-console

--- a/core/systems/utils/entityIndex.ts
+++ b/core/systems/utils/entityIndex.ts
@@ -201,7 +201,6 @@ export function createQueries(sim: Sim) {
       true
     ),
     productionByModules: new Index(sim, ["production", "parent"]),
-    renderable: new Index(sim, ["render", "position"]),
     renderableGraphics: new Index(sim, ["renderGraphics"]),
     sectors: new Index(sim, sectorComponents, [], true),
     selectable: new Index(sim, ["render", "position"], ["selection"]),

--- a/core/systems/utils/sectorIndex.ts
+++ b/core/systems/utils/sectorIndex.ts
@@ -3,6 +3,7 @@ import type { Sim } from "@core/sim";
 import type { EntityTag } from "@core/tags";
 import type { RequireComponent } from "@core/tsHelpers";
 import { Observable } from "@core/utils/observer";
+import { flatMap, pipe } from "@fxts/core";
 import type { IndexEntities } from "./entityIndex";
 import { BaseIndex } from "./entityIndex";
 
@@ -35,7 +36,14 @@ export class SectorIndex<T extends keyof CoreComponents> {
     this.index.hooks.remove.subscribe(this.constructor.name, (entityId) => {
       this.remove(entityId);
     });
+    this.index.collect();
   }
+
+  all = (): IterableIterator<RequireComponent<T>> =>
+    pipe(
+      this.sectors.keys(),
+      flatMap((sector) => this.get(sector))
+    );
 
   changePosition = (
     oldSector: number,

--- a/core/tags.ts
+++ b/core/tags.ts
@@ -13,6 +13,7 @@ const tags = [
   "asteroid",
   "virtual",
   "collectible",
+  "discovered",
   "ai:attack-force",
   "ai:spare",
   ...shipRoles.map<`role:${ShipRole}`>((role) => `role:${role}`),

--- a/core/utils/misc.ts
+++ b/core/utils/misc.ts
@@ -1,12 +1,11 @@
 import { sectorSize } from "@core/archetypes/sector";
 import { ship } from "@core/archetypes/ship";
-import { hecsToCartesian } from "@core/components/hecsPosition";
 import type { Position2D } from "@core/components/position";
 import type { Entity } from "@core/entity";
 import settings from "@core/settings";
 import type { RequireComponent } from "@core/tsHelpers";
 import { first } from "@fxts/core";
-import { add, norm, random, subtract } from "mathjs";
+import { add, norm, random } from "mathjs";
 
 export function isOwnedByPlayer(entity: Entity): boolean {
   return entity!.cp.owner?.id === first(entity.sim.queries.player.getIt())!.id;
@@ -40,18 +39,7 @@ export function getRandomPositionInBounds(
       random(-distance, distance),
       random(-distance, distance),
     ]);
-  } while (
-    (norm(
-      subtract(
-        hecsToCartesian(
-          entity.sim.getOrThrow(entity.cp.position.sector).cp.hecsPosition!
-            .value,
-          sectorSize / 10
-        ),
-        position
-      ) as Position2D
-    ) as number) > sectorSize
-  );
+  } while ((norm(position) as number) > sectorSize);
 
   return position;
 }

--- a/core/world/asteroids.ts
+++ b/core/world/asteroids.ts
@@ -1,11 +1,10 @@
-import { add, random } from "mathjs";
+import { random } from "mathjs";
 import type { Position2D } from "@core/components/position";
 import type { MineableCommodity } from "../economy/commodity";
 import { createAsteroidField } from "../archetypes/asteroidField";
 import type { Sim } from "../sim";
 import type { Sector } from "../archetypes/sector";
 import { sectorSize } from "../archetypes/sector";
-import { hecsToCartesian } from "../components/hecsPosition";
 
 const densities: Record<MineableCommodity, [number, number]> = {
   fuelium: [100, 600],
@@ -31,21 +30,14 @@ export function spawnAsteroidField(
 ) {
   const maxR = (sectorSize / 20) * Math.sqrt(3);
 
-  const sectorCenterPosition = hecsToCartesian(
-    sector.cp.hecsPosition.value,
-    sectorSize / 10
-  );
   const polarPosition = {
     r: random(0, maxR - size - 0.5),
     a: random(-Math.PI, Math.PI),
   };
-  const position = add(
-    [
-      polarPosition.r * Math.cos(polarPosition.a),
-      polarPosition.r * Math.sin(polarPosition.a),
-    ],
-    sectorCenterPosition
-  ) as Position2D;
+  const position: Position2D = [
+    polarPosition.r * Math.cos(polarPosition.a),
+    polarPosition.r * Math.sin(polarPosition.a),
+  ];
 
   createAsteroidField(sim, position, sector, {
     asteroidResources: {

--- a/core/world/factions.ts
+++ b/core/world/factions.ts
@@ -1,13 +1,11 @@
-import type { Position2D } from "@core/components/position";
 import { addStartingCommodities } from "@core/systems/ai/facilityPlanning";
-import { add, random } from "mathjs";
+import { random } from "mathjs";
 import type { Faction } from "../archetypes/faction";
 import { createFaction } from "../archetypes/faction";
 import type { Sector } from "../archetypes/sector";
 import { sectorSize } from "../archetypes/sector";
 import { setMoney } from "../components/budget";
 import type { DockSize } from "../components/dockable";
-import { hecsToCartesian } from "../components/hecsPosition";
 import type { Sim } from "../sim";
 import { requestShip } from "../systems/ai/shipPlanning";
 import { pickRandom, pickRandomWithIndex } from "../utils/generators";
@@ -96,16 +94,10 @@ export function populateSectors(sim: Sim, sectors: Sector[], faction: Faction) {
       {
         owner: faction,
         sector: sectorWithShipyard,
-        position: add(
-          hecsToCartesian(
-            sectorWithShipyard.cp.hecsPosition.value,
-            sectorSize / 10
-          ),
-          [
-            random(-sectorSize / 20, sectorSize / 20),
-            random(-sectorSize / 20, sectorSize / 20),
-          ]
-        ) as Position2D,
+        position: [
+          random(-sectorSize / 20, sectorSize / 20),
+          random(-sectorSize / 20, sectorSize / 20),
+        ],
       },
       sim
     );

--- a/core/world/index.ts
+++ b/core/world/index.ts
@@ -1,13 +1,12 @@
-import { createSector, sectorSize } from "@core/archetypes/sector";
-import { add, random } from "mathjs";
+import { createSector } from "@core/archetypes/sector";
+import { random } from "mathjs";
 import type { PositionAxial } from "@core/components/hecsPosition";
-import { axialToCube, hecsToCartesian } from "@core/components/hecsPosition";
+import { axialToCube } from "@core/components/hecsPosition";
 import type { AiType } from "@core/components/ai";
 import { requestShip } from "@core/systems/ai/shipPlanning";
 import { facilityModules } from "@core/archetypes/facilityModule";
 import { changeRelations } from "@core/components/relations";
 import settings from "@core/settings";
-import type { Position2D } from "@core/components/position";
 import { createFaction } from "../archetypes/faction";
 import { createShip } from "../archetypes/ship";
 import { changeBudgetMoney, createBudget } from "../components/budget";
@@ -121,10 +120,7 @@ export function getFixedWorld(sim: Sim): Promise<void> {
   const playerShip = createShip(sim, {
     ...pickRandom(shipClasses.filter(({ slug }) => slug === "courierA")),
     angle: random(-Math.PI, Math.PI),
-    position: add(
-      hecsToCartesian(startingSector.cp.hecsPosition.value, sectorSize / 10),
-      [random(-1, 1), random(-1, 1)]
-    ) as Position2D,
+    position: [random(-1, 1), random(-1, 1)],
     owner: player,
     sector: startingSector,
   });
@@ -133,10 +129,7 @@ export function getFixedWorld(sim: Sim): Promise<void> {
   const playerMiningShip = createShip(sim, {
     ...shipClasses.find(({ slug }) => slug === "smallMinerA")!,
     angle: random(-Math.PI, Math.PI),
-    position: add(
-      hecsToCartesian(startingSector.cp.hecsPosition.value, sectorSize / 10),
-      [random(-1, 1), random(-1, 1)]
-    ) as Position2D,
+    position: [random(-1, 1), random(-1, 1)],
     owner: player,
     sector: startingSector,
   });
@@ -145,10 +138,7 @@ export function getFixedWorld(sim: Sim): Promise<void> {
   const builderShip = createShip(sim, {
     ...pickRandom(shipClasses.filter(({ role }) => role === "building")),
     angle: random(-Math.PI, Math.PI),
-    position: add(
-      hecsToCartesian(startingSector.cp.hecsPosition.value, sectorSize / 10),
-      [random(-1, 1), random(-1, 1)]
-    ) as Position2D,
+    position: [random(-1, 1), random(-1, 1)],
     owner: player,
     sector: startingSector,
   });
@@ -157,10 +147,7 @@ export function getFixedWorld(sim: Sim): Promise<void> {
   const storageShip = createShip(sim, {
     ...pickRandom(shipClasses.filter(({ role }) => role === "storage")),
     angle: random(-Math.PI, Math.PI),
-    position: add(
-      hecsToCartesian(startingSector.cp.hecsPosition.value, sectorSize / 10),
-      [random(-1, 1), random(-1, 1)]
-    ) as Position2D,
+    position: [random(-1, 1), random(-1, 1)],
     owner: player,
     sector: startingSector,
   });

--- a/core/world/teleporters.ts
+++ b/core/world/teleporters.ts
@@ -28,19 +28,12 @@ export function createLink(
   const [telA, telB] = sectors.map((sector, sectorIndex) => {
     let linkPosition: Position2D;
     if (!position?.[sectorIndex]) {
-      const sectorPosition = hecsToCartesian(
-        sector.cp.hecsPosition.value,
-        sectorSize / 10
-      );
       const a =
         (sectorIndex === 0 ? angle : Math.PI + angle) +
         random(-Math.PI / 6, Math.PI / 6);
       const r = random(20, 35);
 
-      linkPosition = [
-        r * Math.cos(a) + sectorPosition[0],
-        r * Math.sin(a) + sectorPosition[1],
-      ];
+      linkPosition = [r * Math.cos(a), r * Math.sin(a)];
     } else {
       linkPosition = position[sectorIndex];
     }

--- a/ui/components/TradeFinder/TradeFinder.tsx
+++ b/ui/components/TradeFinder/TradeFinder.tsx
@@ -33,7 +33,8 @@ export const TradeFinder: React.FC = () => {
               entity.cp.trade.offers[selectedCommodity].quantity > 0 &&
               sim.queries.player.get()[0].cp.relations.values[
                 entity.cp.owner.id
-              ] > relationThresholds.trade
+              ] > relationThresholds.trade &&
+              entity.tags.has("discovered")
           ),
         `components.trade.offers.${selectedCommodity}.price`
       ),

--- a/ui/views/Game.tsx
+++ b/ui/views/Game.tsx
@@ -49,6 +49,7 @@ const Game: React.FC = () => {
   const [overlay, setOverlay] = useGameOverlay();
   const { addNotification } = useNotifications();
   const [gameSettings] = useGameSettings();
+  const pressedKeys = React.useRef(new Set<string>());
 
   const selectedId = sim.queries.settings.get()[0]!.cp.selectionManager.id;
   const [selectedEntity, setSelectedEntity] = React.useState<
@@ -94,7 +95,9 @@ const Game: React.FC = () => {
   }, [menu.active]);
 
   React.useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      pressedKeys.current.add(event.code);
+
       if (event.code === "Escape") {
         if (overlay) {
           setOverlay(null);
@@ -119,11 +122,24 @@ const Game: React.FC = () => {
         if (sim.speed === 0) sim.unpause();
         else sim.pause();
       }
+
+      if (
+        event.code.startsWith("Digit") &&
+        pressedKeys.current.has("ShiftLeft")
+      ) {
+        if (event.code === "Digit1") sim.setSpeed(1);
+        if (event.code === "Digit2") sim.setSpeed(5);
+        if (event.code === "Digit3" && gameSettings.dev) sim.setSpeed(50);
+      }
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      pressedKeys.current.delete(event.code);
     };
 
-    document.addEventListener("keydown", handler);
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("keyup", onKeyUp);
 
-    return () => document.removeEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", onKeyDown);
   }, [setDialog, overlay, gameSettings.dev]);
 
   React.useEffect(() => {


### PR DESCRIPTION
This MR finally implements fog of war mechanics 🚀 

Fog of war ensures player is not omniscient about state of the world and is forced to deploy their units with some sector coverage strategy in mind. Adding this mechanics to game also allows creating missions like "search" or "escort" when the enemy units can come from any direction and the risk assessment will not be as easy as it was before.

<img width="1680" alt="Screenshot 2024-04-02 at 16 53 10" src="https://github.com/sectoralphagame/sector-alpha/assets/6833443/6feef7db-9132-4ab4-bb82-a5e9caa59e1a">
