### PR TITLE
Add average frame time graph

### DIFF
--- a/core/systems/reporting/avgFrameReporting.ts
+++ b/core/systems/reporting/avgFrameReporting.ts
@@ -1,5 +1,9 @@
 import type { Sim } from "@core/sim";
+import { Observable } from "@core/utils/observer";
 import { System } from "../system";
+
+export const frameData = new Observable<number[]>("frameData", false);
+frameData.value = [];
 
 export class AvgFrameReportingSystem extends System {
   start = 0;
@@ -19,6 +23,9 @@ export class AvgFrameReportingSystem extends System {
         description: "Toggle average frame time reporting",
         fn: () => {
           this.reporting = !this.reporting;
+          if (!this.reporting) {
+            frameData.notify([]);
+          }
         },
       },
       this.constructor.name
@@ -36,7 +43,12 @@ export class AvgFrameReportingSystem extends System {
 
       if (this.iterations === 60) {
         // eslint-disable-next-line no-console
-        console.log("Avg frame time: ", (this.accumulator / 60).toFixed(2));
+        const newData = frameData.value.slice();
+        newData.unshift(this.accumulator / 60);
+        if (newData.length > 31) {
+          newData.pop();
+        }
+        frameData.notify(newData);
         this.iterations = 0;
         this.accumulator = 0;
       }

--- a/ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraph.stories.tsx
+++ b/ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraph.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import type { StoryFn, Meta } from "@storybook/react";
+import { Styles } from "@kit/theming/style";
+import { SimAvgTimeGraphComponent } from "./SimAvgTimeGraphComponent";
+
+export default {
+  title: "Dev / Average Sim Frame Time Graph",
+  component: SimAvgTimeGraphComponent,
+  parameters: {
+    layout: "fullscreen",
+  },
+} as Meta<typeof SimAvgTimeGraphComponent>;
+
+const Template: StoryFn<typeof SimAvgTimeGraphComponent> = (args) => (
+  <div id="root">
+    <Styles>
+      <SimAvgTimeGraphComponent {...args} />
+    </Styles>
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  data: [4.31, 6.22, 4.11, 5.33, 4.44, 5.55, 4.66, 5.77, 4.88, 5.99],
+  width: 300,
+  height: 100,
+};

--- a/ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraph.tsx
+++ b/ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraph.tsx
@@ -1,0 +1,19 @@
+import { frameData } from "@core/systems/reporting/avgFrameReporting";
+import { useObservable } from "@ui/hooks/useObservable";
+import React from "react";
+import { SimAvgTimeGraphComponent } from "./SimAvgTimeGraphComponent";
+import styles from "./styles.scss";
+
+const SimAvgTimeGraph: React.FC = () => {
+  const [data] = useObservable(frameData);
+
+  return (
+    <div className={styles.root}>
+      {data.length > 0 && (
+        <SimAvgTimeGraphComponent data={data} height={100} width={300} />
+      )}
+    </div>
+  );
+};
+
+export default SimAvgTimeGraph;

--- a/ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraphComponent.tsx
+++ b/ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraphComponent.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+interface GraphProps {
+  data: number[];
+  width: number;
+  height: number;
+}
+
+const maxPoints = 31;
+const offsetX = 40;
+const offsetY = 10;
+
+function drawLabel(
+  context: CanvasRenderingContext2D,
+  value: number,
+  width: number,
+  height: number,
+  max: number
+) {
+  const y = height - (value / max) * (height - offsetY);
+  context.beginPath();
+  context.lineWidth = 1;
+  context.moveTo(offsetX, y);
+  context.lineTo(width, y);
+  context.stroke();
+
+  context.textAlign = "right";
+  context.fillText(value.toFixed(2), offsetX - 5, y + 4);
+}
+
+export const SimAvgTimeGraphComponent: React.FC<GraphProps> = ({
+  data,
+  width,
+  height,
+}) => {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    const styles = getComputedStyle(canvasRef.current!);
+    const max = Math.max(...data);
+
+    if (context) {
+      // Clear the canvas
+      context.clearRect(0, 0, width, height);
+
+      // Calculate the scaling factor
+      const scaleFactor = (height - offsetY) / max;
+
+      // Draw the graph
+      context.strokeStyle = styles.getPropertyValue("--palette-primary");
+      context.lineWidth = 2;
+      context.moveTo(width, height - data[0] * scaleFactor);
+      for (let i = 1; i < data.length; i++) {
+        const x =
+          ((width - offsetX) / (maxPoints - 1)) * (maxPoints - i - 1) +
+          offsetX +
+          2;
+        context.beginPath();
+        context.moveTo(x, height);
+        context.lineTo(x, height - data[i] * scaleFactor);
+        context.stroke();
+      }
+
+      // Draw the axes
+      context.beginPath();
+      context.strokeStyle = styles.getPropertyValue("--palette-border");
+      context.lineWidth = 1;
+      context.moveTo(offsetX, offsetY - 5);
+      context.lineTo(offsetX, height);
+      context.lineTo(width, height);
+      context.stroke();
+
+      context.strokeStyle = styles.getPropertyValue("--palette-text-3");
+      context.fillStyle = styles.getPropertyValue("--palette-text-1");
+      context.font = "normal 12px Monospace";
+      [max, (max * 3) / 4, max / 2, max / 4].forEach((value) =>
+        drawLabel(context, value, width, height, max)
+      );
+
+      context.fillStyle = styles.getPropertyValue("--palette-primary");
+      context.textAlign = "right";
+      context.fillText(data[0].toFixed(2), offsetX - 5, height);
+    }
+  }, [data, width, height]);
+
+  return <canvas ref={canvasRef} width={width} height={height} />;
+};

--- a/ui/components/dev/SimAvgTimeGraph/styles.scss
+++ b/ui/components/dev/SimAvgTimeGraph/styles.scss
@@ -1,0 +1,8 @@
+.root {
+  position: fixed;
+  top: 120px;
+  right: 0;
+  pointer-events: none;
+  background-color: var(--palette-background);
+  padding: var(--spacing);
+}

--- a/ui/components/dev/SimAvgTimeGraph/styles.scss.d.ts
+++ b/ui/components/dev/SimAvgTimeGraph/styles.scss.d.ts
@@ -1,0 +1,4 @@
+/* @generated */
+/* prettier-ignore */
+/* eslint-disable */
+export const root: string;

--- a/ui/views/Game.tsx
+++ b/ui/views/Game.tsx
@@ -20,6 +20,7 @@ import { SimControl } from "@ui/components/SimControl/SimControl";
 import DevOverlay from "@ui/components/DevOverlay/DevOverlay";
 import { useGameSettings } from "@ui/hooks/useGameSettings";
 import { SelectedUnit } from "@ui/components/SelectedUnit";
+import SimAvgTimeGraph from "@ui/components/dev/SimAvgTimeGraph/SimAvgTimeGraph";
 import styles from "./Game.scss";
 
 import { Panel } from "../components/Panel";
@@ -166,6 +167,7 @@ const Game: React.FC = () => {
       any changes made by pixi, like cursor property. That's why rendering
       system creates own canvas here */}
       <div className={styles.canvasRoot} ref={canvasRoot} id="canvasRoot">
+        <SimAvgTimeGraph />
         <PlayerMoney />
         <SimControl />
         <SelectedUnit />


### PR DESCRIPTION
This PR adds graph tracking sim time frame changes. It is a successor to average time frame reporting in inspector's console.

<img width="353" alt="Screenshot 2024-05-18 at 02 35 11" src="https://github.com/sectoralphagame/sector-alpha/assets/6833443/361b2c52-3a5c-4dd0-a936-4b7f91f7ec5d">
