### PR TITLE
Singleton systems

### DIFF
--- a/core/sim/baseConfig.ts
+++ b/core/sim/baseConfig.ts
@@ -1,82 +1,82 @@
 import { isDev } from "@core/settings";
-import { FacilityPlanningSystem } from "@core/systems/ai/facilityPlanning";
-import { MilitaryModuleSpottingSystem } from "@core/systems/ai/militaryModuleSpotting";
-import { OrderPlanningSystem } from "@core/systems/ai/orderPlanning";
-import { ShipPlanningSystem } from "@core/systems/ai/shipPlanning";
-import { ShipReturningSystem } from "@core/systems/ai/shipReturning";
-import { SpottingSystem } from "@core/systems/ai/spotting";
-import { TauHarassingSystem } from "@core/systems/ai/tauHarassing";
-import { AsteroidSpawningSystem } from "@core/systems/asteroidSpawning";
-import { AttackingSystem } from "@core/systems/attacking";
-import { BudgetPlanningSystem } from "@core/systems/budgetPlanning";
-import { CollectibleUnregisteringSystem } from "@core/systems/collectibleUnregistering";
-import { CooldownUpdatingSystem } from "@core/systems/cooldowns";
-import { CrewGrowingSystem } from "@core/systems/crewGrowing";
-import { DeadUnregisteringSystem } from "@core/systems/deadUnregistering";
-import { DisposableUnregisteringSystem } from "@core/systems/disposableUnregistering";
-import { FacilityBuildingSystem } from "@core/systems/facilityBuilding";
-import { HitpointsRegeneratingSystem } from "@core/systems/hitpointsRegenerating";
-import { InflationStatisticGatheringSystem } from "@core/systems/inflationStatisticGathering";
-import { MiningSystem } from "@core/systems/mining";
-import { MovingSystem } from "@core/systems/moving";
-import { NavigatingSystem } from "@core/systems/navigating";
-import { OrderExecutingSystem } from "@core/systems/orderExecuting/orderExecuting";
-import { PathPlanningSystem } from "@core/systems/pathPlanning";
-import { PirateSpawningSystem } from "@core/systems/pirateSpawning";
-import { ProducingSystem } from "@core/systems/producing";
+import { facilityPlanningSystem } from "@core/systems/ai/facilityPlanning";
+import { militaryModuleSpottingSystem } from "@core/systems/ai/militaryModuleSpotting";
+import { orderPlanningSystem } from "@core/systems/ai/orderPlanning";
+import { shipPlanningSystem } from "@core/systems/ai/shipPlanning";
+import { shipReturningSystem } from "@core/systems/ai/shipReturning";
+import { spottingSystem } from "@core/systems/ai/spotting";
+import { tauHarassingSystem } from "@core/systems/ai/tauHarassing";
+import { asteroidSpawningSystem } from "@core/systems/asteroidSpawning";
+import { attackingSystem } from "@core/systems/attacking";
+import { budgetPlanningSystem } from "@core/systems/budgetPlanning";
+import { collectibleUnregisteringSystem } from "@core/systems/collectibleUnregistering";
+import { cooldownUpdatingSystem } from "@core/systems/cooldowns";
+import { crewGrowingSystem } from "@core/systems/crewGrowing";
+import { deadUnregisteringSystem } from "@core/systems/deadUnregistering";
+import { disposableUnregisteringSystem } from "@core/systems/disposableUnregistering";
+import { facilityBuildingSystem } from "@core/systems/facilityBuilding";
+import { hitpointsRegeneratingSystem } from "@core/systems/hitpointsRegenerating";
+import { inflationStatisticGatheringSystem } from "@core/systems/inflationStatisticGathering";
+import { miningSystem } from "@core/systems/mining";
+import { movingSystem } from "@core/systems/moving";
+import { navigatingSystem } from "@core/systems/navigating";
+import { orderExecutingSystem } from "@core/systems/orderExecuting/orderExecuting";
+import { pathPlanningSystem } from "@core/systems/pathPlanning";
+import { pirateSpawningSystem } from "@core/systems/pirateSpawning";
+import { producingSystem } from "@core/systems/producing";
 import { AvgFrameReportingSystem } from "@core/systems/reporting/avgFrameReporting";
-import { SectorStatisticGatheringSystem } from "@core/systems/sectorStatisticGathering";
-import { SelectingSystem } from "@core/systems/selecting";
-import { ShipBuildingSystem } from "@core/systems/shipBuilding";
-import { StorageQuotaPlanningSystem } from "@core/systems/storageQuotaPlanning";
+import { sectorStatisticGatheringSystem } from "@core/systems/sectorStatisticGathering";
+import { selectingSystem } from "@core/systems/selecting";
+import { shipBuildingSystem } from "@core/systems/shipBuilding";
+import { storageQuotaPlanningSystem } from "@core/systems/storageQuotaPlanning";
 import { tradingSystem } from "@core/systems/trading";
-import { UndeployingSystem } from "@core/systems/undeploying";
-import { FogOfWarUpdatingSystem } from "@core/systems/fogOfWarUpdating";
-import { StorageTransferringSystem } from "@core/systems/storageTransferring";
+import { undeployingSystem } from "@core/systems/undeploying";
+import { fogOfWarUpdatingSystem } from "@core/systems/fogOfWarUpdating";
+import { storageTransferringSystem } from "@core/systems/storageTransferring";
 import type { SimConfig } from "./Sim";
 
 export const bootstrapSystems = [
-  new PathPlanningSystem(),
-  new CooldownUpdatingSystem(),
-  new ProducingSystem(),
-  new StorageQuotaPlanningSystem(),
+  pathPlanningSystem,
+  cooldownUpdatingSystem,
+  producingSystem,
+  storageQuotaPlanningSystem,
   tradingSystem,
-  new BudgetPlanningSystem(),
-  new OrderPlanningSystem(),
-  new NavigatingSystem(),
-  new MovingSystem(),
-  new MiningSystem(),
-  new OrderExecutingSystem(),
-  new AsteroidSpawningSystem(),
-  new FacilityPlanningSystem(),
-  new ShipPlanningSystem(),
-  new SectorStatisticGatheringSystem(),
-  new InflationStatisticGatheringSystem(),
-  new ShipBuildingSystem(),
-  new FacilityBuildingSystem(),
-  new ShipReturningSystem(),
-  new DisposableUnregisteringSystem(),
-  new CrewGrowingSystem(),
-  new StorageTransferringSystem(),
+  budgetPlanningSystem,
+  orderPlanningSystem,
+  navigatingSystem,
+  movingSystem,
+  miningSystem,
+  orderExecutingSystem,
+  asteroidSpawningSystem,
+  facilityPlanningSystem,
+  shipPlanningSystem,
+  sectorStatisticGatheringSystem,
+  inflationStatisticGatheringSystem,
+  shipBuildingSystem,
+  facilityBuildingSystem,
+  shipReturningSystem,
+  disposableUnregisteringSystem,
+  crewGrowingSystem,
+  storageTransferringSystem,
 ];
 
 export const createBaseConfig = async (): Promise<SimConfig> => {
-  const { MissionSystem } = await import("@core/systems/mission/mission");
+  const { missionSystem } = await import("@core/systems/mission/mission");
   const config: SimConfig = {
     systems: [
       ...bootstrapSystems,
-      new SelectingSystem(),
-      new UndeployingSystem(),
-      new AttackingSystem(),
-      new SpottingSystem(),
-      new MilitaryModuleSpottingSystem(),
-      new HitpointsRegeneratingSystem(),
-      new TauHarassingSystem(),
-      new DeadUnregisteringSystem(),
-      new CollectibleUnregisteringSystem(),
-      new MissionSystem(),
-      new PirateSpawningSystem(),
-      new FogOfWarUpdatingSystem(),
+      selectingSystem,
+      undeployingSystem,
+      attackingSystem,
+      spottingSystem,
+      militaryModuleSpottingSystem,
+      hitpointsRegeneratingSystem,
+      tauHarassingSystem,
+      deadUnregisteringSystem,
+      collectibleUnregisteringSystem,
+      missionSystem,
+      pirateSpawningSystem,
+      fogOfWarUpdatingSystem,
     ],
   };
 

--- a/core/systems/ai/facilityPlanning.ts
+++ b/core/systems/ai/facilityPlanning.ts
@@ -364,3 +364,5 @@ export class FacilityPlanningSystem extends System<"plan"> {
     }
   };
 }
+
+export const facilityPlanningSystem = new FacilityPlanningSystem();

--- a/core/systems/ai/militaryModuleSpotting.ts
+++ b/core/systems/ai/militaryModuleSpotting.ts
@@ -60,3 +60,5 @@ export class MilitaryModuleSpottingSystem extends System<"exec"> {
     this.cooldowns.use("exec", 1 + Math.random());
   };
 }
+
+export const militaryModuleSpottingSystem = new MilitaryModuleSpottingSystem();

--- a/core/systems/ai/orderPlanning.ts
+++ b/core/systems/ai/orderPlanning.ts
@@ -494,3 +494,5 @@ export class OrderPlanningSystem extends System<"exec"> {
     }
   };
 }
+
+export const orderPlanningSystem = new OrderPlanningSystem();

--- a/core/systems/ai/shipPlanning.ts
+++ b/core/systems/ai/shipPlanning.ts
@@ -585,3 +585,5 @@ export class ShipPlanningSystem extends System<"plan"> {
     }
   };
 }
+
+export const shipPlanningSystem = new ShipPlanningSystem();

--- a/core/systems/ai/shipReturning.ts
+++ b/core/systems/ai/shipReturning.ts
@@ -69,3 +69,5 @@ export class ShipReturningSystem extends System<"exec"> {
     );
   };
 }
+
+export const shipReturningSystem = new ShipReturningSystem();

--- a/core/systems/ai/spotting.ts
+++ b/core/systems/ai/spotting.ts
@@ -127,3 +127,5 @@ export class SpottingSystem extends System<"exec"> {
     this.cooldowns.use("exec", 1 + Math.random());
   };
 }
+
+export const spottingSystem = new SpottingSystem();

--- a/core/systems/ai/tauHarassing.ts
+++ b/core/systems/ai/tauHarassing.ts
@@ -199,3 +199,5 @@ export class TauHarassingSystem extends System<"exec"> {
     }
   };
 }
+
+export const tauHarassingSystem = new TauHarassingSystem();

--- a/core/systems/asteroidSpawning.ts
+++ b/core/systems/asteroidSpawning.ts
@@ -26,3 +26,5 @@ export class AsteroidSpawningSystem extends System<"exec"> {
     }
   };
 }
+
+export const asteroidSpawningSystem = new AsteroidSpawningSystem();

--- a/core/systems/attacking.ts
+++ b/core/systems/attacking.ts
@@ -143,3 +143,5 @@ export class AttackingSystem extends System {
     }
   };
 }
+
+export const attackingSystem = new AttackingSystem();

--- a/core/systems/budgetPlanning.ts
+++ b/core/systems/budgetPlanning.ts
@@ -47,3 +47,5 @@ export class BudgetPlanningSystem extends System<"exec"> {
     }
   };
 }
+
+export const budgetPlanningSystem = new BudgetPlanningSystem();

--- a/core/systems/collectibleUnregistering.ts
+++ b/core/systems/collectibleUnregistering.ts
@@ -16,3 +16,6 @@ export class CollectibleUnregisteringSystem extends System {
     }
   };
 }
+
+export const collectibleUnregisteringSystem =
+  new CollectibleUnregisteringSystem();

--- a/core/systems/cooldowns.ts
+++ b/core/systems/cooldowns.ts
@@ -11,3 +11,5 @@ export class CooldownUpdatingSystem extends System {
     this.sim.entities.forEach((entity) => entity.cooldowns.update(delta));
   };
 }
+
+export const cooldownUpdatingSystem = new CooldownUpdatingSystem();

--- a/core/systems/crewGrowing.ts
+++ b/core/systems/crewGrowing.ts
@@ -149,3 +149,5 @@ export class CrewGrowingSystem extends System<"exec"> {
     this.cooldowns.use("exec", gameDay);
   };
 }
+
+export const crewGrowingSystem = new CrewGrowingSystem();

--- a/core/systems/deadUnregistering.ts
+++ b/core/systems/deadUnregistering.ts
@@ -35,3 +35,5 @@ export class DeadUnregisteringSystem extends System {
     }
   };
 }
+
+export const deadUnregisteringSystem = new DeadUnregisteringSystem();

--- a/core/systems/disposableUnregistering.ts
+++ b/core/systems/disposableUnregistering.ts
@@ -30,3 +30,6 @@ export class DisposableUnregisteringSystem extends System<"exec"> {
     }
   };
 }
+
+export const disposableUnregisteringSystem =
+  new DisposableUnregisteringSystem();

--- a/core/systems/facilityBuilding.ts
+++ b/core/systems/facilityBuilding.ts
@@ -122,3 +122,5 @@ export class FacilityBuildingSystem extends System<"build" | "offers"> {
     }
   };
 }
+
+export const facilityBuildingSystem = new FacilityBuildingSystem();

--- a/core/systems/fogOfWarUpdating.ts
+++ b/core/systems/fogOfWarUpdating.ts
@@ -162,3 +162,5 @@ export class FogOfWarUpdatingSystem extends System<"exec"> {
 
   static getDivisions = () => divisions;
 }
+
+export const fogOfWarUpdatingSystem = new FogOfWarUpdatingSystem();

--- a/core/systems/hitpointsRegenerating.ts
+++ b/core/systems/hitpointsRegenerating.ts
@@ -38,3 +38,5 @@ export class HitpointsRegeneratingSystem extends System<"exec"> {
     }
   };
 }
+
+export const hitpointsRegeneratingSystem = new HitpointsRegeneratingSystem();

--- a/core/systems/inflationStatisticGathering.ts
+++ b/core/systems/inflationStatisticGathering.ts
@@ -63,3 +63,6 @@ export class InflationStatisticGatheringSystem extends System {
     }
   };
 }
+
+export const inflationStatisticGatheringSystem =
+  new InflationStatisticGatheringSystem();

--- a/core/systems/mining.ts
+++ b/core/systems/mining.ts
@@ -47,3 +47,5 @@ export class MiningSystem extends System {
     }
   };
 }
+
+export const miningSystem = new MiningSystem();

--- a/core/systems/mission/mission.ts
+++ b/core/systems/mission/mission.ts
@@ -150,3 +150,5 @@ export class MissionSystem extends System<"generate" | "track"> {
     this.track();
   };
 }
+
+export const missionSystem = new MissionSystem();

--- a/core/systems/moving.ts
+++ b/core/systems/moving.ts
@@ -51,3 +51,5 @@ export class MovingSystem extends System {
     }
   };
 }
+
+export const movingSystem = new MovingSystem();

--- a/core/systems/navigating.ts
+++ b/core/systems/navigating.ts
@@ -269,3 +269,5 @@ export class NavigatingSystem extends System {
     }
   };
 }
+
+export const navigatingSystem = new NavigatingSystem();

--- a/core/systems/orderExecuting/misc.ts
+++ b/core/systems/orderExecuting/misc.ts
@@ -51,6 +51,10 @@ export function undockAction(
   >,
   _order: UndockAction
 ): boolean {
+  // FIXME: This is a workaround for the issue with pirate ships undocking from
+  // aparently nowhere
+  if (!entity.cp.dockable?.dockedIn) return true;
+
   entity.cp.dockable.undocking = true;
   entity.cp.drive.active = true;
   entity.cp.drive.target = null;

--- a/core/systems/orderExecuting/orderExecuting.ts
+++ b/core/systems/orderExecuting/orderExecuting.ts
@@ -305,3 +305,5 @@ export class OrderExecutingSystem extends System {
     }
   };
 }
+
+export const orderExecutingSystem = new OrderExecutingSystem();

--- a/core/systems/pathPlanning.ts
+++ b/core/systems/pathPlanning.ts
@@ -42,3 +42,5 @@ export class PathPlanningSystem extends System<"regen"> {
     }
   };
 }
+
+export const pathPlanningSystem = new PathPlanningSystem();

--- a/core/systems/pirateSpawning.ts
+++ b/core/systems/pirateSpawning.ts
@@ -257,3 +257,5 @@ export class PirateSpawningSystem extends System<
     sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
   };
 }
+
+export const pirateSpawningSystem = new PirateSpawningSystem();

--- a/core/systems/producing.ts
+++ b/core/systems/producing.ts
@@ -193,3 +193,5 @@ export class ProducingSystem extends System<"exec"> {
     this.cooldowns.use("exec", gameDay);
   };
 }
+
+export const producingSystem = new ProducingSystem();

--- a/core/systems/sectorStatisticGathering.ts
+++ b/core/systems/sectorStatisticGathering.ts
@@ -38,3 +38,6 @@ export class SectorStatisticGatheringSystem extends System {
     }
   };
 }
+
+export const sectorStatisticGatheringSystem =
+  new SectorStatisticGatheringSystem();

--- a/core/systems/selecting.ts
+++ b/core/systems/selecting.ts
@@ -34,3 +34,5 @@ export class SelectingSystem extends SystemWithHooks {
     this.onChange(this.manager.cp.selectionManager.id, this.refresh);
   };
 }
+
+export const selectingSystem = new SelectingSystem();

--- a/core/systems/shipBuilding.ts
+++ b/core/systems/shipBuilding.ts
@@ -68,3 +68,5 @@ export class ShipBuildingSystem extends System<"exec"> {
     }
   };
 }
+
+export const shipBuildingSystem = new ShipBuildingSystem();

--- a/core/systems/storageQuotaPlanning.ts
+++ b/core/systems/storageQuotaPlanning.ts
@@ -68,3 +68,5 @@ export class StorageQuotaPlanningSystem extends System<"settle"> {
     }
   };
 }
+
+export const storageQuotaPlanningSystem = new StorageQuotaPlanningSystem();

--- a/core/systems/storageTransferring.ts
+++ b/core/systems/storageTransferring.ts
@@ -30,3 +30,5 @@ export class StorageTransferringSystem extends System<"exec"> {
     }
   };
 }
+
+export const storageTransferringSystem = new StorageTransferringSystem();

--- a/core/systems/undeploying.ts
+++ b/core/systems/undeploying.ts
@@ -68,3 +68,5 @@ export class UndeployingSystem extends System<"exec"> {
     }
   };
 }
+
+export const undeployingSystem = new UndeployingSystem();


### PR DESCRIPTION
This PR changes the way systems are included into sim. Instead of constructing them in baseConfig, systems are now instantiated immidiately and rely on proper `apply`/`destroy` method usage, effectively introducing singleton patterns, as hacing multiple instances of the same system is not expected. This also allows importing systems and using their methods directly in UI and utility code.