### PR TITLE
Reset orders after commander reassignment

### DIFF
--- a/core/components/commander.ts
+++ b/core/components/commander.ts
@@ -6,7 +6,9 @@ export interface Commander extends BaseComponent<"commander"> {
   id: number;
 }
 
-export function removeCommander(entity: RequireComponent<"commander">) {
+export function removeCommander(
+  entity: RequireComponent<"commander" | "orders">
+) {
   removeSubordinate(
     entity.sim.getOrThrow<RequireComponent<"subordinates">>(
       entity.cp.commander.id
@@ -16,7 +18,7 @@ export function removeCommander(entity: RequireComponent<"commander">) {
 }
 
 export function changeCommander(
-  entity: RequireComponent<"commander">,
+  entity: RequireComponent<"commander" | "orders">,
   commander: RequireComponent<"subordinates">
 ) {
   removeCommander(entity);

--- a/core/components/subordinates.ts
+++ b/core/components/subordinates.ts
@@ -1,5 +1,6 @@
 import type { Entity } from "@core/entity";
 import type { RequireComponent } from "@core/tsHelpers";
+import { cleanupOrders } from "@core/systems/orderExecuting/orderExecuting";
 import type { BaseComponent } from "./component";
 
 export interface Subordinates extends BaseComponent<"subordinates"> {
@@ -34,10 +35,11 @@ export function addSubordinate(
 
 export function removeSubordinate(
   entity: RequireComponent<"subordinates">,
-  subordinate: RequireComponent<"commander">
+  subordinate: RequireComponent<"commander" | "orders">
 ) {
   entity.cp.subordinates.ids = entity.cp.subordinates.ids.filter(
     (id) => id !== subordinate.id
   );
   subordinate.removeComponent("commander");
+  cleanupOrders(subordinate);
 }

--- a/core/systems/ai/shipPlanning.ts
+++ b/core/systems/ai/shipPlanning.ts
@@ -281,7 +281,7 @@ export class ShipPlanningSystem extends System<"plan"> {
           .slice(0, -trading)
       );
     spareTraders.forEach((ship) => {
-      removeCommander(ship.requireComponents(["commander"]));
+      removeCommander(ship.requireComponents(["commander", "orders"]));
     });
     spareTraders.push(
       ...this.sim.index.orderable
@@ -361,7 +361,7 @@ export class ShipPlanningSystem extends System<"plan"> {
             .slice(0, -mining) ?? []
       );
     spareMiners.forEach((ship) => {
-      removeCommander(ship.requireComponents(["commander"]));
+      removeCommander(ship.requireComponents(["commander", "orders"]));
     });
     spareMiners.push(
       ...this.sim.index.mining

--- a/core/systems/orderExecuting/deployBuilder.ts
+++ b/core/systems/orderExecuting/deployBuilder.ts
@@ -11,7 +11,7 @@ export function deployBuilderAction(
   order: BuilderDeployAction
 ): boolean {
   if (entity.cp.commander) {
-    removeCommander(entity.requireComponents(["commander"]));
+    removeCommander(entity.requireComponents(["commander", "orders"]));
   }
 
   (["autoOrder", "orders"] as Array<keyof CoreComponents>).reduce(

--- a/core/systems/orderExecuting/orderExecuting.ts
+++ b/core/systems/orderExecuting/orderExecuting.ts
@@ -114,7 +114,7 @@ function cleanupAllocations(entity: Entity): void {
   });
 }
 
-function cleanupOrders(entity: Entity): void {
+export function cleanupOrders(entity: Entity): void {
   if (
     (["asteroid", "virtual"] as EntityTag[]).some((tag) => entity.tags.has(tag))
   )
@@ -194,7 +194,7 @@ function cleanupChildren(entity: Entity): void {
   if (entity.cp.commander) {
     removeSubordinate(
       entity.sim.getOrThrow(entity.cp.commander.id),
-      entity.requireComponents(["commander"])
+      entity.requireComponents(["commander", "orders"])
     );
   }
 

--- a/core/utils/ownership.ts
+++ b/core/utils/ownership.ts
@@ -11,7 +11,7 @@ export function transferOwnership(
   const newOwner = faction(entity.sim.getOrThrow(newOwnerId));
   entity.cp.owner.id = newOwnerId;
 
-  if (entity.hasComponents(["commander"])) {
+  if (entity.hasComponents(["commander", "orders"])) {
     removeSubordinate(entity.sim.getOrThrow(entity.cp.commander.id), entity);
   }
 

--- a/ui/components/Commander.tsx
+++ b/ui/components/Commander.tsx
@@ -9,7 +9,7 @@ import styles from "./Commander.scss";
 
 export interface CommanderProps {
   commander: Entity;
-  ship: RequireComponent<"commander">;
+  ship: RequireComponent<"commander" | "orders">;
 }
 
 export const Commander: React.FC<CommanderProps> = ({ commander, ship }) => {

--- a/ui/components/Orders.tsx
+++ b/ui/components/Orders.tsx
@@ -130,7 +130,7 @@ const Orders: React.FC<{ ship: Ship }> = ({ ship }) => {
           <CollapsibleSummary>
             <div className={styles.orderGroupHeader}>
               {getOrderGroupDescription(order, ship.sim)}
-              {isOwned && (
+              {isOwned && !ship.cp.commander?.id && (
                 <IconButton
                   onClick={(event) => {
                     event.stopPropagation();

--- a/ui/components/ShipPanel.tsx
+++ b/ui/components/ShipPanel.tsx
@@ -20,7 +20,7 @@ const ShipPanel: React.FC<{ entity: Ship; showSensitive: boolean }> = ({
         <>
           <Commander
             commander={commander}
-            ship={ship.requireComponents(["commander"])}
+            ship={ship.requireComponents(["commander", "orders"])}
           />
           <hr />
         </>


### PR DESCRIPTION
This PR blocks ability to mess up commander's orders; since this PR it is impossible to give orders to a ship, which already has its commander.