### PR TITLE
Add sector claiming mechanics

### DIFF
--- a/core/archetypes/facilityModule.ts
+++ b/core/archetypes/facilityModule.ts
@@ -49,6 +49,9 @@ export interface MilitaryFacilityModuleInput extends FacilityModuleCommonInput {
   damage: Omit<Damage, "name">;
   type: "military";
 }
+export interface SpecialFacilityModuleInput extends FacilityModuleCommonInput {
+  type: "special";
+}
 export type FacilityModuleInput =
   | ProductionFacilityModuleInput
   | StorageFacilityModuleInput
@@ -56,7 +59,8 @@ export type FacilityModuleInput =
   | TeleportFacilityModuleInput
   | HabitatFacilityModuleInput
   | MilitaryFacilityModuleInput
-  | HubFacilityModuleInput;
+  | HubFacilityModuleInput
+  | SpecialFacilityModuleInput;
 
 export type FacilityModuleType = FacilityModuleInput["type"];
 export type FacilityModule = RequireComponent<"parent" | "name">;
@@ -76,6 +80,7 @@ export function createFacilityModule(
     .addComponent({
       name: "name",
       value: input.name,
+      slug: input.slug,
     })
     .addTag("facilityModule")
     .addTag(`facilityModuleType:${input.type}`);

--- a/core/sim/baseConfig.ts
+++ b/core/sim/baseConfig.ts
@@ -33,6 +33,7 @@ import { tradingSystem } from "@core/systems/trading";
 import { undeployingSystem } from "@core/systems/undeploying";
 import { fogOfWarUpdatingSystem } from "@core/systems/fogOfWarUpdating";
 import { storageTransferringSystem } from "@core/systems/storageTransferring";
+import { sectorClaimingSystem } from "@core/systems/sectorClaiming";
 import type { SimConfig } from "./Sim";
 
 export const bootstrapSystems = [
@@ -77,6 +78,7 @@ export const createBaseConfig = async (): Promise<SimConfig> => {
       missionSystem,
       pirateSpawningSystem,
       fogOfWarUpdatingSystem,
+      sectorClaimingSystem,
     ],
   };
 

--- a/core/systems/sectorClaiming.ts
+++ b/core/systems/sectorClaiming.ts
@@ -1,0 +1,41 @@
+import type { Sim } from "../sim";
+import { System } from "./system";
+import { defaultIndexer } from "./utils/default";
+import { EntityIndex } from "./utils/entityIndex";
+
+export class SectorClaimingSystem extends System<"exec"> {
+  index = new EntityIndex(["parent"], ["facilityModuleType:hub"]);
+
+  apply = (sim: Sim): void => {
+    super.apply(sim);
+    this.index.apply(sim);
+
+    sim.hooks.phase.update.subscribe(this.constructor.name, this.exec);
+  };
+
+  exec = (): void => {
+    if (this.cooldowns.canUse("exec")) {
+      this.cooldowns.use("exec", 1);
+
+      const hubs = this.index
+        .get()
+        .map((e) =>
+          this.sim
+            .getOrThrow(e.cp.parent.id)
+            .requireComponents(["owner", "position"])
+        );
+
+      for (const sector of defaultIndexer.sectors.getIt()) {
+        const hub = hubs.find((h) => h.cp.position.sector === sector.id);
+
+        if (!sector.cp.owner && hub) {
+          sector.addComponent({ name: "owner", id: hub.cp.owner.id });
+        } else if (!hub) {
+          sector.removeComponent("owner");
+        }
+      }
+    }
+  };
+}
+
+export const sectorClaimingSystem = new SectorClaimingSystem();

--- a/core/world/data/base.json
+++ b/core/world/data/base.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:669807acb94537ccba7985ea55bf9dcab9dc0e97e8715e6d651a6535a93ca77b
-size 4853988
+oid sha256:4f746d2de434e06b55a0e45e69ccf24aa13dcd87c7c73a2d404a42a9453798e3
+size 4900569

--- a/core/world/data/facilityModules.json
+++ b/core/world/data/facilityModules.json
@@ -321,5 +321,13 @@
       "time": 370
     },
     "crew": { "cost": 21 }
+  },
+  {
+    "name": "Tau Hive",
+    "type": "special",
+    "pac": {},
+    "slug": "tauHive",
+    "build": { "cost": { "tauMetal": 9700, "fuel": 1550 }, "time": 1080 },
+    "crew": { "cost": 0 }
   }
 ]

--- a/core/world/data/facilityTemplates.json
+++ b/core/world/data/facilityTemplates.json
@@ -15,5 +15,20 @@
       "farm",
       "farm"
     ]
+  },
+  {
+    "name": "Outpost Hive",
+    "slug": "outpostHive",
+    "modules": [
+      "tauHive",
+      "tauHive",
+      "tauHive",
+      "smallDefense",
+      "smallDefense",
+      "smallDefense",
+      "smallDefense",
+      "smallDefense",
+      "smallDefense"
+    ]
   }
 ]

--- a/devtools/facilityBuilder/index.tsx
+++ b/devtools/facilityBuilder/index.tsx
@@ -85,7 +85,6 @@ const FacilityBuilder: React.FC = () => {
         {modules.map((fm, fmIndex) => (
           <div className={styles.selectedModule} key={fm.slug + fmIndex}>
             <IconButton
-              disabled={initialModules.includes(fm.slug)}
               onClick={() => {
                 setModuleIds((pfm) => pfm.filter((_, i) => i !== fmIndex));
                 setModified(true);
@@ -103,7 +102,13 @@ const FacilityBuilder: React.FC = () => {
           </DropdownButton>
           <DropdownOptions>
             {facilityModules
-              .filter((fm) => !initialModules.includes(fm.slug))
+              .filter(
+                (fm) =>
+                  !(
+                    initialModules.includes(fm.slug) &&
+                    !modules.find((m) => m.slug === fm.slug)
+                  )
+              )
               .map((fm) => (
                 <DropdownOption
                   key={fm.slug}

--- a/devtools/facilityModules/General.tsx
+++ b/devtools/facilityModules/General.tsx
@@ -54,6 +54,7 @@ const FacilityModuleGeneralEditor: React.FC<{ index: number }> = ({
             <SelectOption value="habitat">Habitat</SelectOption>
             <SelectOption value="military">Military</SelectOption>
             <SelectOption value="hub">Hub</SelectOption>
+            <SelectOption value="special">Special</SelectOption>
           </SelectOptions>
         </Select>
       </TableCell>

--- a/kit/BaseButton.tsx
+++ b/kit/BaseButton.tsx
@@ -13,12 +13,12 @@ export type BaseButtonProps = React.DetailedHTMLProps<
 
 export const defaultClickSound = new Howl({
   src: click,
-  volume: 0.5,
+  volume: 0.2,
 });
 
 export const popSound = new Howl({
   src: pop,
-  volume: 0.5,
+  volume: 0.2,
 });
 
 export const BaseButton: React.FC<BaseButtonProps> = ({


### PR DESCRIPTION
This PR adds sector claiming mechanics. Now sector is claimed by building hub - and, analogically, unclaimed by destroying one. Tau claim sectors by building Hive Outposts.