### PR TITLE
Fix missing settings error

### DIFF
--- a/ui/hooks/useGameSettings.ts
+++ b/ui/hooks/useGameSettings.ts
@@ -1,5 +1,17 @@
 import { defaultGameSttings } from "@core/settings";
+import { useMemo } from "react";
+import merge from "lodash/merge";
 import { useLocalStorage } from "./useLocalStorage";
 
-export const useGameSettings = () =>
-  useLocalStorage("gameSettings", defaultGameSttings);
+export function useGameSettings() {
+  const [settingsFromStorage, setSettings] = useLocalStorage(
+    "gameSettings",
+    defaultGameSttings
+  );
+  const settings = useMemo(
+    () => merge({}, defaultGameSttings, settingsFromStorage),
+    [settingsFromStorage]
+  );
+
+  return [settings, setSettings] as const;
+}


### PR DESCRIPTION
This PR fixes game crash if player has an outdated settings saved in a browser and is missing a setting.