### PR TITLE
Uniform interface

### DIFF
--- a/ogl-engine/engine/Camera.ts
+++ b/ogl-engine/engine/Camera.ts
@@ -1,5 +1,5 @@
 import type { FolderApi } from "tweakpane";
-import { Camera as BaseCamera, Vec3 } from "ogl";
+import { Camera as BaseCamera, Mat4, Vec3 } from "ogl";
 import { getPane } from "@ui/context/Pane";
 import type { Engine } from "./engine";
 
@@ -8,6 +8,10 @@ const tempVec3 = new Vec3();
 export class Camera extends BaseCamera {
   name = "Camera";
   engine: Engine;
+
+  invProjectionMatrix = new Mat4();
+  invViewMatrix = new Mat4();
+  invViewProjectionMatrix = new Mat4();
 
   private paneFolder: FolderApi;
 
@@ -55,5 +59,17 @@ export class Camera extends BaseCamera {
       0,
       cameraPos.z + t * cameraDir.z
     );
+  }
+
+  updateMatrixWorld() {
+    super.updateMatrixWorld();
+
+    this.invProjectionMatrix.inverse(this.projectionMatrix);
+    this.invViewMatrix.inverse(this.viewMatrix);
+    this.invViewProjectionMatrix
+      .copy(this.invProjectionMatrix)
+      .multiply(this.invViewMatrix);
+
+    return this;
   }
 }

--- a/ogl-engine/materials/AsteroidNew/AsteroidNew.ts
+++ b/ogl-engine/materials/AsteroidNew/AsteroidNew.ts
@@ -3,6 +3,7 @@ import { Vec3, type Texture } from "ogl";
 import { assetLoader } from "@ogl-engine/AssetLoader";
 import fragment from "./shader.frag.glsl";
 import vertex from "../pbr/shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 interface AsteroidNewMaterialArgs {
@@ -12,11 +13,11 @@ interface AsteroidNewMaterialArgs {
 
 export class AsteroidNewMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tGrunge: { value: Texture };
-    tNormal: { value: Texture };
-    uMask: { value: number };
-    uColor: { value: Vec3 };
-    uEmissive: { value: number };
+    tGrunge: Uniform<Texture>;
+    tNormal: Uniform<Texture>;
+    uMask: Uniform<number>;
+    uColor: Uniform<Vec3>;
+    uEmissive: Uniform<number>;
   };
 
   constructor(engine: Engine3D, args: AsteroidNewMaterialArgs = {}) {

--- a/ogl-engine/materials/AsteroidNew/AsteroidNew.ts
+++ b/ogl-engine/materials/AsteroidNew/AsteroidNew.ts
@@ -3,7 +3,7 @@ import { Vec3, type Texture } from "ogl";
 import { assetLoader } from "@ogl-engine/AssetLoader";
 import fragment from "./shader.frag.glsl";
 import vertex from "../pbr/shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 interface AsteroidNewMaterialArgs {
@@ -12,13 +12,14 @@ interface AsteroidNewMaterialArgs {
 }
 
 export class AsteroidNewMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tGrunge: Uniform<Texture>;
-    tNormal: Uniform<Texture>;
-    uMask: Uniform<number>;
-    uColor: Uniform<Vec3>;
-    uEmissive: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tGrunge: Texture;
+      tNormal: Texture;
+      uMask: number;
+      uColor: Vec3;
+      uEmissive: number;
+    }>;
 
   constructor(engine: Engine3D, args: AsteroidNewMaterialArgs = {}) {
     super(engine);

--- a/ogl-engine/materials/AsteroidRock/AsteroidRock.ts
+++ b/ogl-engine/materials/AsteroidRock/AsteroidRock.ts
@@ -3,6 +3,7 @@ import { type Texture } from "ogl";
 import { assetLoader } from "@ogl-engine/AssetLoader";
 import fragment from "./shader.frag.glsl";
 import vertex from "../pbr/shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 interface AsteroidRockMaterialArgs {
@@ -11,8 +12,8 @@ interface AsteroidRockMaterialArgs {
 
 export class AsteroidRockMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tGrunge: { value: Texture };
-    tNormal: { value: Texture };
+    tGrunge: Uniform<Texture>;
+    tNormal: Uniform<Texture>;
   };
 
   constructor(engine: Engine3D, args: AsteroidRockMaterialArgs = {}) {

--- a/ogl-engine/materials/AsteroidRock/AsteroidRock.ts
+++ b/ogl-engine/materials/AsteroidRock/AsteroidRock.ts
@@ -3,7 +3,7 @@ import { type Texture } from "ogl";
 import { assetLoader } from "@ogl-engine/AssetLoader";
 import fragment from "./shader.frag.glsl";
 import vertex from "../pbr/shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 interface AsteroidRockMaterialArgs {
@@ -11,10 +11,11 @@ interface AsteroidRockMaterialArgs {
 }
 
 export class AsteroidRockMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tGrunge: Uniform<Texture>;
-    tNormal: Uniform<Texture>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tGrunge: Texture;
+      tNormal: Texture;
+    }>;
 
   constructor(engine: Engine3D, args: AsteroidRockMaterialArgs = {}) {
     super(engine);

--- a/ogl-engine/materials/asteroidDust/asteroidDust.ts
+++ b/ogl-engine/materials/asteroidDust/asteroidDust.ts
@@ -5,14 +5,15 @@ import { assetLoader } from "@ogl-engine/AssetLoader";
 import { colorToVec3 } from "@core/utils/maps";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class AsteroidDustMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tMap: { value: Texture };
-    uColor: { value: Vec3 };
-    uEmissive: { value: number };
-    uAlpha: { value: number };
+    tMap: Uniform<Texture>;
+    uColor: Uniform<Vec3>;
+    uEmissive: Uniform<number>;
+    uAlpha: Uniform<number>;
   };
 
   constructor(

--- a/ogl-engine/materials/asteroidDust/asteroidDust.ts
+++ b/ogl-engine/materials/asteroidDust/asteroidDust.ts
@@ -5,16 +5,17 @@ import { assetLoader } from "@ogl-engine/AssetLoader";
 import { colorToVec3 } from "@core/utils/maps";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class AsteroidDustMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tMap: Uniform<Texture>;
-    uColor: Uniform<Vec3>;
-    uEmissive: Uniform<number>;
-    uAlpha: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tMap: Texture;
+      uColor: Vec3;
+      uEmissive: number;
+      uAlpha: number;
+    }>;
 
   constructor(
     engine: Engine3D,

--- a/ogl-engine/materials/atmosphere/atmosphere.ts
+++ b/ogl-engine/materials/atmosphere/atmosphere.ts
@@ -2,7 +2,7 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import { Vec3 } from "ogl";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 interface AtmosphereMaterialArgs {
@@ -12,11 +12,12 @@ interface AtmosphereMaterialArgs {
 }
 
 export class AtmosphereMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-    uX: Uniform<number>;
-    uY: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+      uX: number;
+      uY: number;
+    }>;
 
   constructor(engine: Engine3D, args: AtmosphereMaterialArgs) {
     super(engine);

--- a/ogl-engine/materials/atmosphere/atmosphere.ts
+++ b/ogl-engine/materials/atmosphere/atmosphere.ts
@@ -2,6 +2,7 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import { Vec3 } from "ogl";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 interface AtmosphereMaterialArgs {
@@ -12,9 +13,9 @@ interface AtmosphereMaterialArgs {
 
 export class AtmosphereMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec3 };
-    uX: { value: number };
-    uY: { value: number };
+    uColor: Uniform<Vec3>;
+    uX: Uniform<number>;
+    uY: Uniform<number>;
   };
 
   constructor(engine: Engine3D, args: AtmosphereMaterialArgs) {

--- a/ogl-engine/materials/color/color.ts
+++ b/ogl-engine/materials/color/color.ts
@@ -6,15 +6,16 @@ import fragment from "./shader.frag.glsl";
 import fragment2d from "./shader2d.frag.glsl";
 import vertex from "./shader.vert.glsl";
 import vertex2d from "./shader2d.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material, Material2D } from "../material";
 
 export class ColorMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-    fEmissive: Uniform<number>;
-    bShaded: { value: boolean };
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+      fEmissive: number;
+      bShaded: boolean;
+    }>;
 
   constructor(
     engine: Engine3D,
@@ -53,9 +54,10 @@ export class ColorMaterial extends Material {
 }
 
 export class ColorMaterial2D extends Material2D {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+    }>;
 
   constructor(engine: Engine2D, color: string) {
     super(engine);

--- a/ogl-engine/materials/color/color.ts
+++ b/ogl-engine/materials/color/color.ts
@@ -6,12 +6,13 @@ import fragment from "./shader.frag.glsl";
 import fragment2d from "./shader2d.frag.glsl";
 import vertex from "./shader.vert.glsl";
 import vertex2d from "./shader2d.vert.glsl";
+import type { Uniform } from "../material";
 import { Material, Material2D } from "../material";
 
 export class ColorMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec3 };
-    fEmissive: { value: number };
+    uColor: Uniform<Vec3>;
+    fEmissive: Uniform<number>;
     bShaded: { value: boolean };
   };
 
@@ -53,7 +54,7 @@ export class ColorMaterial extends Material {
 
 export class ColorMaterial2D extends Material2D {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec3 };
+    uColor: Uniform<Vec3>;
   };
 
   constructor(engine: Engine2D, color: string) {

--- a/ogl-engine/materials/engineTrail/engineTrail.ts
+++ b/ogl-engine/materials/engineTrail/engineTrail.ts
@@ -3,13 +3,14 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import Color from "color";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class EngineTrailMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+    }>;
 
   constructor(engine: Engine3D, color: string) {
     super(engine);

--- a/ogl-engine/materials/engineTrail/engineTrail.ts
+++ b/ogl-engine/materials/engineTrail/engineTrail.ts
@@ -3,11 +3,12 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import Color from "color";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class EngineTrailMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec3 };
+    uColor: Uniform<Vec3>;
   };
 
   constructor(engine: Engine3D, color: string) {

--- a/ogl-engine/materials/entityIndicator/entityIndicator.ts
+++ b/ogl-engine/materials/entityIndicator/entityIndicator.ts
@@ -4,16 +4,17 @@ import type { DockSize } from "@core/components/dockable";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class EntityIndicatorMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uSize: { value: number };
-    uColor: { value: Vec4 };
-    uHp: { value: number };
-    uShield: { value: number };
-    uHovered: { value: number };
-    uSelected: { value: number };
+    uSize: Uniform<number>;
+    uColor: Uniform<Vec4>;
+    uHp: Uniform<number>;
+    uShield: Uniform<number>;
+    uHovered: Uniform<number>;
+    uSelected: Uniform<number>;
   };
 
   constructor(engine: Engine3D) {

--- a/ogl-engine/materials/entityIndicator/entityIndicator.ts
+++ b/ogl-engine/materials/entityIndicator/entityIndicator.ts
@@ -4,18 +4,19 @@ import type { DockSize } from "@core/components/dockable";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class EntityIndicatorMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uSize: Uniform<number>;
-    uColor: Uniform<Vec4>;
-    uHp: Uniform<number>;
-    uShield: Uniform<number>;
-    uHovered: Uniform<number>;
-    uSelected: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uSize: number;
+      uColor: Vec4;
+      uHp: number;
+      uShield: number;
+      uHovered: number;
+      uSelected: number;
+    }>;
 
   constructor(engine: Engine3D) {
     super(engine);

--- a/ogl-engine/materials/entityName/entityName.ts
+++ b/ogl-engine/materials/entityName/entityName.ts
@@ -5,15 +5,16 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import type { DockSize } from "@core/components/dockable";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class EntityNameMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tMap: Uniform<Texture>;
-    uOffset: Uniform<number>;
-    uColor: Uniform<Vec3>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tMap: Texture;
+      uOffset: number;
+      uColor: Vec3;
+    }>;
 
   constructor(engine: Engine3D, texture: Texture) {
     super(engine);

--- a/ogl-engine/materials/entityName/entityName.ts
+++ b/ogl-engine/materials/entityName/entityName.ts
@@ -5,13 +5,14 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import type { DockSize } from "@core/components/dockable";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class EntityNameMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tMap: { value: Texture };
-    uOffset: { value: number };
-    uColor: { value: Vec3 };
+    tMap: Uniform<Texture>;
+    uOffset: Uniform<number>;
+    uColor: Uniform<Vec3>;
   };
 
   constructor(engine: Engine3D, texture: Texture) {

--- a/ogl-engine/materials/kineticGun/kineticGun.ts
+++ b/ogl-engine/materials/kineticGun/kineticGun.ts
@@ -2,6 +2,7 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import { Vec4 } from "ogl";
 import fragment from "./shader.frag.glsl";
 import vertex from "../orb/shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 interface KineticGunMaterialArgs {
@@ -10,7 +11,7 @@ interface KineticGunMaterialArgs {
 
 export class KineticGunMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec4 };
+    uColor: Uniform<Vec4>;
   };
 
   constructor(engine: Engine3D, args: KineticGunMaterialArgs) {

--- a/ogl-engine/materials/kineticGun/kineticGun.ts
+++ b/ogl-engine/materials/kineticGun/kineticGun.ts
@@ -2,7 +2,7 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import { Vec4 } from "ogl";
 import fragment from "./shader.frag.glsl";
 import vertex from "../orb/shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 interface KineticGunMaterialArgs {
@@ -10,9 +10,10 @@ interface KineticGunMaterialArgs {
 }
 
 export class KineticGunMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec4>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec4;
+    }>;
 
   constructor(engine: Engine3D, args: KineticGunMaterialArgs) {
     super(engine);

--- a/ogl-engine/materials/laser/laser.ts
+++ b/ogl-engine/materials/laser/laser.ts
@@ -2,7 +2,7 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import { Vec3 } from "ogl";
 import fragment from "./shader.frag.glsl";
 import vertex from "../base.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 interface LaserMaterialArgs {
@@ -10,11 +10,12 @@ interface LaserMaterialArgs {
 }
 
 export class LaserMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-    uIntensity: Uniform<number>;
-    uAspectRatio: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+      uIntensity: number;
+      uAspectRatio: number;
+    }>;
 
   constructor(engine: Engine3D, { color }: LaserMaterialArgs) {
     super(engine);

--- a/ogl-engine/materials/laserImpact/laserImpact.ts
+++ b/ogl-engine/materials/laserImpact/laserImpact.ts
@@ -2,7 +2,7 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import { Vec3 } from "ogl";
 import fragment from "./shader.frag.glsl";
 import vertex from "../base.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 interface LaserImpactMaterialArgs {
@@ -10,10 +10,11 @@ interface LaserImpactMaterialArgs {
 }
 
 export class LaserImpactMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-    uIntensity: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+      uIntensity: number;
+    }>;
 
   constructor(engine: Engine3D, { color }: LaserImpactMaterialArgs) {
     super(engine);

--- a/ogl-engine/materials/material.ts
+++ b/ogl-engine/materials/material.ts
@@ -4,12 +4,14 @@ import { entries, join, map, pipe } from "@fxts/core";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import type { Light } from "@ogl-engine/engine/Light";
 import Color from "color";
-import type { ProgramOptions, Mesh, Vec3, Vec4, Vec2 } from "ogl";
+import type { ProgramOptions, Mesh, Vec3, Vec4, Vec2, Mat4, Mat3 } from "ogl";
 import { Texture, Program } from "ogl";
 import type { BindingParams, FolderApi } from "tweakpane";
 import { getPane } from "@ui/context/Pane";
 
-export interface Uniform<T extends Vec2 | Vec3 | Vec4 | Texture | number> {
+export interface Uniform<
+  T extends Vec2 | Vec3 | Vec4 | Texture | Mat3 | Mat4 | number
+> {
   value: T;
   meta?: {
     pane?: BindingParams;
@@ -25,6 +27,9 @@ export abstract class Material {
     uTime: Uniform<number>;
     tEnvMap: Uniform<Texture>;
     uCameraScale: Uniform<number>;
+    invProjectionMatrix: Uniform<Mat4>;
+    invViewMatrix: Uniform<Mat4>;
+    invViewProjectionMatrix: Uniform<Mat4>;
   };
 
   constructor(engine: Engine3D) {
@@ -35,6 +40,9 @@ export abstract class Material {
       uTime: engine.uniforms.uTime,
       tEnvMap: engine.uniforms.env.tEnvMap,
       uCameraScale: { value: Math.log2(engine.camera.far) },
+      invProjectionMatrix: { value: engine.camera.invProjectionMatrix },
+      invViewMatrix: { value: engine.camera.invViewMatrix },
+      invViewProjectionMatrix: { value: engine.camera.invViewProjectionMatrix },
     };
   }
 

--- a/ogl-engine/materials/material.ts
+++ b/ogl-engine/materials/material.ts
@@ -20,11 +20,11 @@ export abstract class Material {
   engine: Engine3D;
   protected program: Program;
   protected uniforms: {
-    ambient: { value: Vec3 };
+    ambient: Uniform<Vec3>;
     lights: Light["uniforms"][];
-    uTime: { value: number };
-    tEnvMap: { value: Texture };
-    uCameraScale: { value: number };
+    uTime: Uniform<number>;
+    tEnvMap: Uniform<Texture>;
+    uCameraScale: Uniform<number>;
   };
 
   constructor(engine: Engine3D) {
@@ -116,12 +116,12 @@ export abstract class Material {
     });
   }
 
-  static colorToVec3(color: string, uniform: { value: Vec3 }) {
+  static colorToVec3(color: string, uniform: Uniform<Vec3>) {
     const c = Color(color).rgb().array();
     uniform.value.set(c[0], c[1], c[2]).divide(255);
   }
 
-  static colorToVec4(color: string, uniform: { value: Vec4 }) {
+  static colorToVec4(color: string, uniform: Uniform<Vec4>) {
     const c = Color(color).rgb();
     uniform.value.set(
       c.red() / 255,

--- a/ogl-engine/materials/material.ts
+++ b/ogl-engine/materials/material.ts
@@ -4,32 +4,35 @@ import { entries, join, map, pipe } from "@fxts/core";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import type { Light } from "@ogl-engine/engine/Light";
 import Color from "color";
-import type { ProgramOptions, Mesh, Vec3, Vec4, Vec2, Mat4, Mat3 } from "ogl";
+import type { ProgramOptions, Mesh, Vec3, Vec4, Mat4 } from "ogl";
 import { Texture, Program } from "ogl";
 import type { BindingParams, FolderApi } from "tweakpane";
 import { getPane } from "@ui/context/Pane";
 
-export interface Uniform<
-  T extends Vec2 | Vec3 | Vec4 | Texture | Mat3 | Mat4 | number
-> {
+export interface Uniform<T> {
   value: T;
   meta?: {
     pane?: BindingParams;
   };
 }
 
+export type Uniforms<T extends Record<string, any>> = {
+  [K in keyof T]: Uniform<T[K]>;
+};
+
 export abstract class Material {
   engine: Engine3D;
   protected program: Program;
-  protected uniforms: {
-    ambient: Uniform<Vec3>;
+  protected uniforms: Uniforms<{
+    ambient: Vec3;
+    uTime: number;
+    tEnvMap: Texture;
+    uCameraScale: number;
+    invProjectionMatrix: Mat4;
+    invViewMatrix: Mat4;
+    invViewProjectionMatrix: Mat4;
+  }> & {
     lights: Light["uniforms"][];
-    uTime: Uniform<number>;
-    tEnvMap: Uniform<Texture>;
-    uCameraScale: Uniform<number>;
-    invProjectionMatrix: Uniform<Mat4>;
-    invViewMatrix: Uniform<Mat4>;
-    invViewProjectionMatrix: Uniform<Mat4>;
   };
 
   constructor(engine: Engine3D) {

--- a/ogl-engine/materials/msdf/msdf.ts
+++ b/ogl-engine/materials/msdf/msdf.ts
@@ -4,14 +4,15 @@ import type { Engine } from "@ogl-engine/engine/engine";
 import Color from "color";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { MaterialAny } from "../material";
 
 export class MSDFMaterial extends MaterialAny {
-  uniforms: MaterialAny["uniforms"] & {
-    tMap: Uniform<Texture>;
-    uColor: Uniform<Vec3>;
-  };
+  uniforms: MaterialAny["uniforms"] &
+    Uniforms<{
+      tMap: Texture;
+      uColor: Vec3;
+    }>;
 
   constructor(engine: Engine, texture: Texture) {
     super(engine);

--- a/ogl-engine/materials/msdf/msdf.ts
+++ b/ogl-engine/materials/msdf/msdf.ts
@@ -4,12 +4,13 @@ import type { Engine } from "@ogl-engine/engine/engine";
 import Color from "color";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { MaterialAny } from "../material";
 
 export class MSDFMaterial extends MaterialAny {
   uniforms: MaterialAny["uniforms"] & {
-    tMap: { value: Texture };
-    uColor: { value: Vec3 };
+    tMap: Uniform<Texture>;
+    uColor: Uniform<Vec3>;
   };
 
   constructor(engine: Engine, texture: Texture) {

--- a/ogl-engine/materials/orb/orb.ts
+++ b/ogl-engine/materials/orb/orb.ts
@@ -2,15 +2,16 @@ import type { Vec4 } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class OrbMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uStart: Uniform<Vec4>;
-    uEnd: Uniform<Vec4>;
-    fEmissive: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uStart: Vec4;
+      uEnd: Vec4;
+      fEmissive: number;
+    }>;
 
   constructor(engine: Engine3D, start: Vec4, end: Vec4, global = true) {
     super(engine);

--- a/ogl-engine/materials/orb/orb.ts
+++ b/ogl-engine/materials/orb/orb.ts
@@ -2,13 +2,14 @@ import type { Vec4 } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class OrbMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uStart: { value: Vec4 };
-    uEnd: { value: Vec4 };
-    fEmissive: { value: number };
+    uStart: Uniform<Vec4>;
+    uEnd: Uniform<Vec4>;
+    fEmissive: Uniform<number>;
   };
 
   constructor(engine: Engine3D, start: Vec4, end: Vec4, global = true) {

--- a/ogl-engine/materials/particleCloud/particleCloud.ts
+++ b/ogl-engine/materials/particleCloud/particleCloud.ts
@@ -5,16 +5,17 @@ import { assetLoader } from "@ogl-engine/AssetLoader";
 import { colorToVec3 } from "@core/utils/maps";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class ParticleCloudMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tMap: Uniform<Texture>;
-    uColor: Uniform<Vec3>;
-    uEmissive: Uniform<number>;
-    uAlpha: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tMap: Texture;
+      uColor: Vec3;
+      uEmissive: number;
+      uAlpha: number;
+    }>;
 
   constructor(
     engine: Engine3D,

--- a/ogl-engine/materials/particleCloud/particleCloud.ts
+++ b/ogl-engine/materials/particleCloud/particleCloud.ts
@@ -5,14 +5,15 @@ import { assetLoader } from "@ogl-engine/AssetLoader";
 import { colorToVec3 } from "@core/utils/maps";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class ParticleCloudMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tMap: { value: Texture };
-    uColor: { value: Vec3 };
-    uEmissive: { value: number };
-    uAlpha: { value: number };
+    tMap: Uniform<Texture>;
+    uColor: Uniform<Vec3>;
+    uEmissive: Uniform<number>;
+    uAlpha: Uniform<number>;
   };
 
   constructor(

--- a/ogl-engine/materials/pbr/pbr.ts
+++ b/ogl-engine/materials/pbr/pbr.ts
@@ -2,18 +2,19 @@ import type { GLTFMaterial, Texture } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class PbrMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tDiffuse: Uniform<Texture>;
-    tNormal: Uniform<Texture>;
-    tRoughness: Uniform<Texture>;
-    uRoughness: Uniform<number>;
-    tEmissive: Uniform<Texture>;
-    uMetallic: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tDiffuse: Texture;
+      tNormal: Texture;
+      tRoughness: Texture;
+      uRoughness: number;
+      tEmissive: Texture;
+      uMetallic: number;
+    }>;
 
   constructor(
     engine: Engine3D,

--- a/ogl-engine/materials/pbr/pbr.ts
+++ b/ogl-engine/materials/pbr/pbr.ts
@@ -2,16 +2,17 @@ import type { GLTFMaterial, Texture } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class PbrMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tDiffuse: { value: Texture };
-    tNormal: { value: Texture };
-    tRoughness: { value: Texture };
-    uRoughness: { value: number };
-    tEmissive: { value: Texture };
-    uMetallic: { value: number };
+    tDiffuse: Uniform<Texture>;
+    tNormal: Uniform<Texture>;
+    tRoughness: Uniform<Texture>;
+    uRoughness: Uniform<number>;
+    tEmissive: Uniform<Texture>;
+    uMetallic: Uniform<number>;
   };
 
   constructor(

--- a/ogl-engine/materials/selectionBox/selectionBox.ts
+++ b/ogl-engine/materials/selectionBox/selectionBox.ts
@@ -1,13 +1,14 @@
 import { Program } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
 
 export class SelectionBoxMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    lineWidthX: { value: number };
-    lineWidthY: { value: number };
+    lineWidthX: Uniform<number>;
+    lineWidthY: Uniform<number>;
   };
 
   constructor(engine: Engine3D) {

--- a/ogl-engine/materials/selectionBox/selectionBox.ts
+++ b/ogl-engine/materials/selectionBox/selectionBox.ts
@@ -1,15 +1,16 @@
 import { Program } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
 
 export class SelectionBoxMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    lineWidthX: Uniform<number>;
-    lineWidthY: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      lineWidthX: number;
+      lineWidthY: number;
+    }>;
 
   constructor(engine: Engine3D) {
     super(engine);

--- a/ogl-engine/materials/spritesheet/spritesheet.ts
+++ b/ogl-engine/materials/spritesheet/spritesheet.ts
@@ -1,16 +1,17 @@
 import type { Texture } from "ogl";
 import { Program, Vec4 } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
 
 export class SpritesheetMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tDiffuse: { value: Texture };
-    sprite: { value: Vec4 };
-    fAlpha: { value: number };
-    fEmissive: { value: number };
+    tDiffuse: Uniform<Texture>;
+    sprite: Uniform<Vec4>;
+    fAlpha: Uniform<number>;
+    fEmissive: Uniform<number>;
   };
   index: number;
 

--- a/ogl-engine/materials/spritesheet/spritesheet.ts
+++ b/ogl-engine/materials/spritesheet/spritesheet.ts
@@ -1,18 +1,19 @@
 import type { Texture } from "ogl";
 import { Program, Vec4 } from "ogl";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
 
 export class SpritesheetMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tDiffuse: Uniform<Texture>;
-    sprite: Uniform<Vec4>;
-    fAlpha: Uniform<number>;
-    fEmissive: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tDiffuse: Texture;
+      sprite: Vec4;
+      fAlpha: number;
+      fEmissive: number;
+    }>;
   index: number;
 
   constructor(

--- a/ogl-engine/materials/star/star.ts
+++ b/ogl-engine/materials/star/star.ts
@@ -4,16 +4,17 @@ import smoke from "@assets/textures/smoke.jpg";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class StarMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec3 };
-    uColor2: { value: Vec3 };
-    tSmoke: { value: Texture };
-    uNoise: { value: number };
-    uNoisePower: { value: number };
-    uEmissive: { value: number };
+    uColor: Uniform<Vec3>;
+    uColor2: Uniform<Vec3>;
+    tSmoke: Uniform<Texture>;
+    uNoise: Uniform<number>;
+    uNoisePower: Uniform<number>;
+    uEmissive: Uniform<number>;
   };
 
   constructor(engine: Engine3D) {

--- a/ogl-engine/materials/star/star.ts
+++ b/ogl-engine/materials/star/star.ts
@@ -4,18 +4,19 @@ import smoke from "@assets/textures/smoke.jpg";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class StarMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-    uColor2: Uniform<Vec3>;
-    tSmoke: Uniform<Texture>;
-    uNoise: Uniform<number>;
-    uNoisePower: Uniform<number>;
-    uEmissive: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+      uColor2: Vec3;
+      tSmoke: Texture;
+      uNoise: number;
+      uNoisePower: number;
+      uEmissive: number;
+    }>;
 
   constructor(engine: Engine3D) {
     super(engine);

--- a/ogl-engine/materials/starCorona/starCorona.ts
+++ b/ogl-engine/materials/starCorona/starCorona.ts
@@ -4,13 +4,14 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import Color from "color";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class StarCoronaMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    uColor: Uniform<Vec3>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      uColor: Vec3;
+    }>;
 
   constructor(engine: Engine3D, color: Vec3) {
     super(engine);

--- a/ogl-engine/materials/starCorona/starCorona.ts
+++ b/ogl-engine/materials/starCorona/starCorona.ts
@@ -4,11 +4,12 @@ import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import Color from "color";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class StarCoronaMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    uColor: { value: Vec3 };
+    uColor: Uniform<Vec3>;
   };
 
   constructor(engine: Engine3D, color: Vec3) {

--- a/ogl-engine/materials/tintedTexture/tintedTexture.ts
+++ b/ogl-engine/materials/tintedTexture/tintedTexture.ts
@@ -4,15 +4,16 @@ import Color from "color";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
-import type { Uniform } from "../material";
+import type { Uniforms } from "../material";
 import { Material } from "../material";
 
 export class TintedTextureMaterial extends Material {
-  uniforms: Material["uniforms"] & {
-    tMap: Uniform<Texture>;
-    uColor: Uniform<Vec3>;
-    fEmissive: Uniform<number>;
-  };
+  uniforms: Material["uniforms"] &
+    Uniforms<{
+      tMap: Texture;
+      uColor: Vec3;
+      fEmissive: number;
+    }>;
 
   constructor(engine: Engine3D, texture: Texture, color?: string) {
     super(engine);

--- a/ogl-engine/materials/tintedTexture/tintedTexture.ts
+++ b/ogl-engine/materials/tintedTexture/tintedTexture.ts
@@ -4,13 +4,14 @@ import Color from "color";
 import type { Engine3D } from "@ogl-engine/engine/engine3d";
 import fragment from "./shader.frag.glsl";
 import vertex from "./shader.vert.glsl";
+import type { Uniform } from "../material";
 import { Material } from "../material";
 
 export class TintedTextureMaterial extends Material {
   uniforms: Material["uniforms"] & {
-    tMap: { value: Texture };
-    uColor: { value: Vec3 };
-    fEmissive: { value: number };
+    tMap: Uniform<Texture>;
+    uColor: Uniform<Vec3>;
+    fEmissive: Uniform<number>;
   };
 
   constructor(engine: Engine3D, texture: Texture, color?: string) {


### PR DESCRIPTION
This PR unifies usage of shader uniforms across the project, casting them to one reusable interface `Uniforms`.